### PR TITLE
Add basic multi‑monitor support

### DIFF
--- a/src/commands/command-registry.ts
+++ b/src/commands/command-registry.ts
@@ -31,6 +31,7 @@ import { TailCommand } from './linux/tail';
 import { TouchCommand } from './linux/touch';
 import { WcCommand } from './linux/wc';
 import { LaunchCommand } from './linux/launch';
+import { OpenScreenCommand } from './linux/openscreen';
 
 // Import path alias management commands
 import { AliasCommand } from './linux/alias';
@@ -118,6 +119,7 @@ export class CommandRegistry {
     this.registerCommand(new ManCommand(this.os));
     this.registerCommand(new NanoEditor(this.os));
     this.registerCommand(new LaunchCommand(this.os));
+    this.registerCommand(new OpenScreenCommand(this.os));
     
     // Register path alias management commands
     this.registerCommand(new AliasCommand(this.os));

--- a/src/commands/linux/openscreen.ts
+++ b/src/commands/linux/openscreen.ts
@@ -1,0 +1,29 @@
+import { CommandModule, CommandArgs, CommandContext } from '../command-processor';
+import { OS } from '../../core/os';
+
+export class OpenScreenCommand implements CommandModule {
+  private os: OS;
+
+  constructor(os: OS) {
+    this.os = os;
+  }
+
+  public get name(): string {
+    return 'openscreen';
+  }
+
+  public get description(): string {
+    return 'Open a secondary monitor window';
+  }
+
+  public get usage(): string {
+    return 'openscreen [monitorId]';
+  }
+
+  public async execute(args: CommandArgs, context: CommandContext): Promise<number> {
+    const id = args.args.length > 0 ? parseInt(args.args[0], 10) : 2;
+    this.os.getMultiMonitorManager().openMonitor(id);
+    context.stdout.writeLine(`Opening monitor ${id}`);
+    return 0;
+  }
+}

--- a/src/core/os.ts
+++ b/src/core/os.ts
@@ -15,6 +15,7 @@ import { ComputerSettings } from './ComputerSettings';
 import { createIcons, icons } from 'lucide';
 import { ThemeSystem } from './theme-system';
 import { InitComponents } from './components/init';
+import { MultiMonitorManager } from './multi-monitor';
 /**
  * Main OS class that manages the entire operating system simulation
  */
@@ -37,12 +38,14 @@ export class OS {
   private computerSettings: ComputerSettings;
   private isReady: boolean = false;
   private readyCallbacks: Array<() => void> = [];
+  private multiMonitor: MultiMonitorManager;
   themeSystem: ThemeSystem;
   constructor() {
     this.initIcons(); // Initialize icons using lucide
     this.fileSystem = new FileSystem(this);
     this.processManager = new ProcessManager();
-    this.windowManager = new WindowManager();
+    this.multiMonitor = new MultiMonitorManager();
+    this.windowManager = new WindowManager(this.multiMonitor);
     this.systemMonitor = new SystemMonitor(this.processManager);
     this.appManager = new AppManager(this);
     this.commandProcessor = new CommandProcessor(this);
@@ -196,8 +199,14 @@ export class OS {
    */
   public getDesktop(): Desktop {
     return this.desktop;
-  } public getWebClient(): WebClient {
+  }
+
+  public getWebClient(): WebClient {
     return this.webClient;
+  }
+
+  public getMultiMonitorManager(): MultiMonitorManager {
+    return this.multiMonitor;
   }
 
   /**

--- a/src/core/themes/macos.ts
+++ b/src/core/themes/macos.ts
@@ -79,55 +79,55 @@ export function createMacOSTheme(): Theme {
       textAlignment: 'center',
       height: '28px',
       customCss: `
-      #windows-container .window-header .window-title{
+      .windows-container .window-header .window-title{
         color: black !important;
         margin-left: 11px !important;
         font-weight: 500;
         font-size: 13px;
       } 
-        #windows-container .window {
+        .windows-container .window {
             border-radius: ${windowBorderRadius}px;
             box-shadow: 0 5px 30px rgba(0, 0, 0, 0.2);
             border: 1px solid rgba(0, 0, 0, 0.2);
             overflow: hidden;
         }
-        #windows-container .window.active {
+        .windows-container .window.active {
             border: 1px solid rgba(0, 0, 0, 0.3);
             box-shadow: 0 8px 40px rgba(0, 0, 0, 0.25);
-        }        #windows-container .window-header .window-controls{
+        }        .windows-container .window-header .window-controls{
             flex-direction: row;
         }
-            #windows-container .window {
+            .windows-container .window {
             border-radius: ${windowBorderRadius}px;
             border: 1px solid rgba(0, 0, 0, 0.15);
             box-shadow: 0 8px 30px rgba(0, 0, 0, 0.15);
             overflow: hidden;
             }
-            #windows-container .window-header {
+            .windows-container .window-header {
             border-radius: ${windowBorderRadius}px ${windowBorderRadius}px 0 0;
             padding: 0 ${windowBorderRadius-8}px;
         }
-            #windows-container .window-content, 
-            #windows-container .window-content > div {
+            .windows-container .window-content,
+            .windows-container .window-content > div {
 
                 border-radius: 0 0 ${windowBorderRadius}px ${windowBorderRadius}px;
 }
             /* Style for code editor window content */
-            .app-code-editor #windows-container .window-content {
+            .app-code-editor .windows-container .window-content {
                 background-color: #1e1e1e;
                 color: #f0f0f0;
             }
             /* Style for terminal window content */
-            .app-terminal #windows-container .window-content {
+            .app-terminal .windows-container .window-content {
                 background-color: #1e1e1e;
                 color: #f0f0f0;
             }
             /* General content style for native macOS appearance */
-            #windows-container .window-content,
-            #windows-container .window {
+            .windows-container .window-content,
+            .windows-container .window {
                 background-color: #f5f5f7;
             }
-             #windows-container .window-header .window-controls .window-control {
+             .windows-container .window-header .window-controls .window-control {
             border-radius: 50%;
             /*width: 12px;
             height: 12px;*/
@@ -136,12 +136,12 @@ export function createMacOSTheme(): Theme {
             box-shadow: inset 0 0 0 0.5px rgba(255, 255, 255, 0.15);
             transition: all 0.1s ease-in-out;
         }
-        #windows-container .window-header .window-controls {
+        .windows-container .window-header .window-controls {
             margin-left: 8px;
             display: flex;
             gap: 3px;
         }
-        #windows-container .window-header {
+        .windows-container .window-header {
             flex-direction: row-reverse;
         }        
         .window-control.window-close {

--- a/src/index.html
+++ b/src/index.html
@@ -19,7 +19,8 @@
     </div>
 
 <div id="desktop-icons"></div>
-    <div id="windows-container"></div>
+    <div id="windows-container-1" class="windows-container"></div>
+    <div id="windows-container-2" class="windows-container"></div>
   </div>
 </body>
 </html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,24 @@ import { OS } from './core/os';
 
 // Initialize the operating system when the page loads
 document.addEventListener('DOMContentLoaded', () => {
-  
+  const params = new URLSearchParams(window.location.search);
+  const monitorIdParam = params.get('monitor');
+  const isSecondary = monitorIdParam !== null || !!window.opener;
+
   const os = new OS();
+  if (isSecondary) {
+    os.getMultiMonitorManager().connectAsSecondary();
+
+    document.getElementById('taskbar')?.remove();
+    document.getElementById('desktop-icons')?.remove();
+
+    const id = monitorIdParam ? parseInt(monitorIdParam, 10) : 2;
+    document.querySelectorAll('.windows-container').forEach(el => {
+      if (el.id !== `windows-container-${id}`) {
+        (el as HTMLElement).style.display = 'none';
+      }
+    });
+  }
+
   os.init();
 });


### PR DESCRIPTION
## Summary
- add monitor containers in index.html
- update macOS theme styles for new container class
- integrate MultiMonitorManager with OS and WindowManager
- support monitor ID in WindowManager and sync events via BroadcastChannel
- detect secondary monitor in index.ts
- add `openscreen` command to open additional monitors

## Testing
- `npm run tsc:debug` *(fails: Cannot find module errors)*