### PR TITLE
Add basic Blazor window component

### DIFF
--- a/wasm/HackerSimulator.Wasm/Core/ProcessBase.cs
+++ b/wasm/HackerSimulator.Wasm/Core/ProcessBase.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
 
 namespace HackerSimulator.Wasm.Core
 {
-    public abstract class ProcessBase
+    public abstract class ProcessBase : ComponentBase
     {
         protected ProcessBase(string name) => Name = name;
 

--- a/wasm/HackerSimulator.Wasm/Program.cs
+++ b/wasm/HackerSimulator.Wasm/Program.cs
@@ -19,6 +19,7 @@ namespace HackerSimulator.Wasm
 
             builder.Services.AddSingleton<NetworkService>();
             builder.Services.AddSingleton<DnsService>();
+            builder.Services.AddSingleton<Windows.WindowManagerService>();
 
 
             await builder.Build().RunAsync();

--- a/wasm/HackerSimulator.Wasm/Windows/WindowBase.razor
+++ b/wasm/HackerSimulator.Wasm/Windows/WindowBase.razor
@@ -1,0 +1,31 @@
+@inherits HackerSimulator.Wasm.Windows.WindowBase
+
+<div class="hs-window @(IsActive ? "active" : "")" style="@Style" @onmousedown="HandleClick" @onmousemove="OnMouseMove" @onmouseup="StopDrag">
+    <div class="hs-window-header" @ondblclick="ToggleMaximize" @onmousedown="StartDrag">
+        @if (!string.IsNullOrEmpty(Icon))
+        {
+            <img class="hs-window-icon" src="@Icon" />
+        }
+        <span class="hs-window-title">@Title</span>
+        <div class="hs-window-buttons">
+            <button @onclick="Minimize">_</button>
+            <button @onclick="ToggleMaximize">@((State==WindowState.Maximized?"🗗":"🗖"))</button>
+            <button @onclick="Close">x</button>
+        </div>
+    </div>
+    <div class="hs-window-content">
+        <CascadingValue Value="this">
+            @ChildContent
+        </CascadingValue>
+    </div>
+</div>
+
+<style>
+.hs-window { position:absolute; background:#222; color:#eee; border:1px solid #444; }
+.hs-window-header { background:#333; padding:4px; display:flex; align-items:center; cursor:move; user-select:none; }
+.hs-window-icon { width:16px; height:16px; }
+.hs-window-title { flex:1; margin-left:4px; }
+.hs-window-buttons button { margin-left:4px; }
+.hs-window-content { overflow:auto; height:calc(100% - 30px); padding:4px; }
+.hs-window.active { border-color:#66f; }
+</style>

--- a/wasm/HackerSimulator.Wasm/Windows/WindowBase.razor.cs
+++ b/wasm/HackerSimulator.Wasm/Windows/WindowBase.razor.cs
@@ -1,0 +1,132 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using System;
+using System.ComponentModel;
+
+namespace HackerSimulator.Wasm.Windows
+{
+    public partial class WindowBase : ProcessBase, IDisposable
+    {
+        [Inject] private WindowManagerService Manager { get; set; } = default!;
+
+        [Parameter] public RenderFragment? ChildContent { get; set; }
+        [Parameter] public string Title { get; set; } = "Window";
+        [Parameter] public string? Icon { get; set; }
+        [Parameter] public bool Resizable { get; set; } = true;
+
+        public bool Visible { get; set; } = true;
+
+        public double X { get; set; } = 100;
+        public double Y { get; set; } = 100;
+        public double Width { get; set; } = 400;
+        public double Height { get; set; } = 300;
+
+        public WindowState State { get; private set; } = WindowState.Normal;
+
+        internal bool IsActive { get; private set; }
+
+        private bool _dragging;
+        private double _startX;
+        private double _startY;
+        private double _startLeft;
+        private double _startTop;
+
+        protected override void OnInitialized()
+        {
+            base.OnInitialized();
+            Manager.Register(this);
+        }
+
+        public void Activate()
+        {
+            Manager.Activate(this);
+        }
+
+        internal void InvokeActivated(bool active)
+        {
+            IsActive = active;
+            StateHasChanged();
+        }
+
+        private void HandleClick()
+        {
+            if (!IsActive)
+                Activate();
+        }
+
+        private void StartDrag(MouseEventArgs e)
+        {
+            _dragging = true;
+            _startX = e.ClientX;
+            _startY = e.ClientY;
+            _startLeft = X;
+            _startTop = Y;
+            Activate();
+        }
+
+        private void OnMouseMove(MouseEventArgs e)
+        {
+            if (!_dragging) return;
+            X = _startLeft + (e.ClientX - _startX);
+            Y = _startTop + (e.ClientY - _startY);
+        }
+
+        private void StopDrag()
+        {
+            _dragging = false;
+        }
+
+        private void ToggleMaximize()
+        {
+            if (State == WindowState.Maximized)
+                Restore();
+            else
+                Maximize();
+        }
+
+        public void Maximize()
+        {
+            State = WindowState.Maximized;
+            X = 0;
+            Y = 0;
+            Width = 10000; // full width (handled via style)
+            Height = 10000;
+        }
+
+        public void Restore()
+        {
+            State = WindowState.Normal;
+            Width = 400;
+            Height = 300;
+        }
+
+        public void Minimize()
+        {
+            State = WindowState.Minimized;
+            Visible = false;
+        }
+
+        public void Close()
+        {
+            var args = new CancelEventArgs();
+            OnClose?.Invoke(this, args);
+            if (args.Cancel)
+                return;
+            OnClosed?.Invoke(this, EventArgs.Empty);
+            Visible = false;
+            Manager.Unregister(this);
+        }
+
+        public event EventHandler<CancelEventArgs>? OnClose;
+        public event EventHandler? OnClosed;
+
+        string Style => $"left:{X}px;top:{Y}px;width:{Width}px;height:{Height}px;" +
+                         (Resizable ? "resize:both;overflow:hidden;" : "") +
+                         (Visible ? "" : "display:none;");
+
+        public void Dispose()
+        {
+            Manager.Unregister(this);
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Windows/WindowManagerService.cs
+++ b/wasm/HackerSimulator.Wasm/Windows/WindowManagerService.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+
+namespace HackerSimulator.Wasm.Windows
+{
+    /// <summary>
+    /// Simple service that keeps track of open windows and activation state.
+    /// </summary>
+    public class WindowManagerService
+    {
+        private readonly List<WindowBase> _windows = new();
+        private WindowBase? _active;
+
+        public IReadOnlyList<WindowBase> Windows => _windows;
+
+        internal void Register(WindowBase window)
+        {
+            if (!_windows.Contains(window))
+                _windows.Add(window);
+
+            Activate(window);
+        }
+
+        internal void Unregister(WindowBase window)
+        {
+            _windows.Remove(window);
+            if (_active == window)
+                _active = null;
+        }
+
+        public void Activate(WindowBase window)
+        {
+            if (_active == window)
+                return;
+
+            _active?.InvokeActivated(false);
+            _active = window;
+            _active.InvokeActivated(true);
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Windows/WindowState.cs
+++ b/wasm/HackerSimulator.Wasm/Windows/WindowState.cs
@@ -1,0 +1,9 @@
+namespace HackerSimulator.Wasm.Windows
+{
+    public enum WindowState
+    {
+        Normal,
+        Minimized,
+        Maximized
+    }
+}

--- a/wasm/HackerSimulator.Wasm/_Imports.razor
+++ b/wasm/HackerSimulator.Wasm/_Imports.razor
@@ -6,3 +6,4 @@
 @using HackerSimulator.Wasm
 @using HackerSimulator.Wasm.Shared
 @using HackerSimulator.Wasm.Core
+@using HackerSimulator.Wasm.Windows


### PR DESCRIPTION
## Summary
- extend `ProcessBase` from `ComponentBase` so processes can be Blazor components
- introduce window management service
- implement initial `WindowBase` component with activation, drag and basic buttons
- register the new service in `Program`
- update imports for window namespace

## Testing
- `dotnet build wasm/HackerSimulator.Wasm/HackerSimulator.Wasm.csproj -nologo` *(fails: Unable to load NuGet packages)*