### PR TITLE
Improve taskbar tracking and remove build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,5 @@ dist
 # .NET build artifacts
 src/wasm/HackerSimulator.Wasm/bin/
 src/wasm/HackerSimulator.Wasm/obj/
+wasm/HackerSimulator.Wasm/bin/
+wasm/HackerSimulator.Wasm/obj/

--- a/wasm/HackerSimulator.Wasm/Commands/CommandContext.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/CommandContext.cs
@@ -8,6 +8,6 @@ namespace HackerSimulator.Wasm.Commands
         public TextReader Stdin { get; set; } = TextReader.Null;
         public TextWriter Stdout { get; set; } = TextWriter.Null;
         public TextWriter Stderr { get; set; } = TextWriter.Null;
-        public Dictionary<string, string> Env { get; } = new();
+        public Dictionary<string, string> Env { get; set; } = new();
     }
 }

--- a/wasm/HackerSimulator.Wasm/Core/FileSystemService.cs
+++ b/wasm/HackerSimulator.Wasm/Core/FileSystemService.cs
@@ -300,7 +300,7 @@ namespace HackerSimulator.Wasm.Core
             return Task.FromResult(_entries.TryGetValue(path, out var rec) && rec.Entry.IsBinary);
         }
 
-        private class FileStats
+        public class FileStats
         {
             public bool IsDirectory { get; set; }
             public long? Size { get; set; }

--- a/wasm/HackerSimulator.Wasm/Shared/MainLayout.razor
+++ b/wasm/HackerSimulator.Wasm/Shared/MainLayout.razor
@@ -7,11 +7,13 @@
         @Body
     </main>
 </div>
+<Taskbar />
 
 <style>
 .container {
     display: flex;
     min-height: 100vh;
+    padding-bottom: 40px; /* space for taskbar */
 }
 main {
     flex: 1;

--- a/wasm/HackerSimulator.Wasm/Shared/Taskbar.razor
+++ b/wasm/HackerSimulator.Wasm/Shared/Taskbar.razor
@@ -1,0 +1,100 @@
+@implements IDisposable
+@inject WindowManagerService WindowManager
+
+<div class="taskbar">
+    <button class="start-button">Start</button>
+    @foreach (var win in _windows)
+    {
+        <button class="task-button @(win == _active ? "active" : "")" @onclick="() => Activate(win)">
+            @if (!string.IsNullOrEmpty(win.Icon))
+            {
+                <img src="@win.Icon" class="task-icon" />
+            }
+            <span class="task-title">@win.Title</span>
+        </button>
+    }
+</div>
+
+<style>
+.taskbar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 40px;
+    background: #111;
+    display: flex;
+    align-items: center;
+}
+.start-button {
+    margin: 0 4px;
+    height: 32px;
+}
+.task-button {
+    display: flex;
+    align-items: center;
+    margin: 0 2px;
+    padding: 0 6px;
+    height: 32px;
+    background: #222;
+    color: #eee;
+    border: none;
+}
+.task-button.active {
+    background: #444;
+}
+.task-icon {
+    width: 16px;
+    height: 16px;
+    margin-right: 4px;
+}
+</style>
+
+@code {
+    private readonly List<WindowBase> _windows = new();
+    private WindowBase? _active;
+
+    protected override void OnInitialized()
+    {
+        _windows.AddRange(WindowManager.Windows);
+        WindowManager.WindowOpened += OnWindowOpened;
+        WindowManager.WindowClosed += OnWindowClosed;
+        WindowManager.ActiveWindowChanged += OnActiveWindowChanged;
+        _active = WindowManager.Windows.FirstOrDefault(w => w.IsActive);
+    }
+
+    private void OnWindowOpened(WindowBase win)
+    {
+        _windows.Add(win);
+        StateHasChanged();
+    }
+
+    private void OnWindowClosed(WindowBase win)
+    {
+        _windows.Remove(win);
+        StateHasChanged();
+    }
+
+    private void OnActiveWindowChanged(WindowBase? win)
+    {
+        _active = win;
+        StateHasChanged();
+    }
+
+    private void Activate(WindowBase win)
+    {
+        if (win.State == WindowState.Minimized)
+        {
+            win.Visible = true;
+            win.Restore();
+        }
+        win.Activate();
+    }
+
+    public void Dispose()
+    {
+        WindowManager.WindowOpened -= OnWindowOpened;
+        WindowManager.WindowClosed -= OnWindowClosed;
+        WindowManager.ActiveWindowChanged -= OnActiveWindowChanged;
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Windows/WindowBase.razor
+++ b/wasm/HackerSimulator.Wasm/Windows/WindowBase.razor
@@ -1,5 +1,4 @@
-@inherits HackerSimulator.Wasm.Windows.WindowBase
-
+@inherits HackerSimulator.Wasm.Core.ProcessBase
 <div class="hs-window @(IsActive ? "active" : "")" style="@Style" @onmousedown="HandleClick" @onmousemove="OnMouseMove" @onmouseup="StopDrag">
     <div class="hs-window-header" @ondblclick="ToggleMaximize" @onmousedown="StartDrag">
         @if (!string.IsNullOrEmpty(Icon))

--- a/wasm/HackerSimulator.Wasm/Windows/WindowBase.razor.cs
+++ b/wasm/HackerSimulator.Wasm/Windows/WindowBase.razor.cs
@@ -2,12 +2,19 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using System;
 using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
 
 namespace HackerSimulator.Wasm.Windows
 {
-    public partial class WindowBase : ProcessBase, IDisposable
+    public partial class WindowBase : IDisposable
     {
         [Inject] private WindowManagerService Manager { get; set; } = default!;
+
+        public WindowBase() : base("window")
+        {
+        }
 
         [Parameter] public RenderFragment? ChildContent { get; set; }
         [Parameter] public string Title { get; set; } = "Window";
@@ -127,6 +134,12 @@ namespace HackerSimulator.Wasm.Windows
         public void Dispose()
         {
             Manager.Unregister(this);
+        }
+
+        protected override Task RunAsync(string[] args, CancellationToken token)
+        {
+            // Windows have no background execution logic by default
+            return Task.CompletedTask;
         }
     }
 }

--- a/wasm/HackerSimulator.Wasm/Windows/WindowManagerService.cs
+++ b/wasm/HackerSimulator.Wasm/Windows/WindowManagerService.cs
@@ -10,12 +10,31 @@ namespace HackerSimulator.Wasm.Windows
         private readonly List<WindowBase> _windows = new();
         private WindowBase? _active;
 
+        /// <summary>
+        /// Raised when a window is opened and registered with the manager.
+        /// </summary>
+        public event Action<WindowBase>? WindowOpened;
+
+        /// <summary>
+        /// Raised when a window is closed and unregistered from the manager.
+        /// </summary>
+        public event Action<WindowBase>? WindowClosed;
+
+        /// <summary>
+        /// Raised whenever the active window changes. Emits <c>null</c> when no
+        /// window is active.
+        /// </summary>
+        public event Action<WindowBase?>? ActiveWindowChanged;
+
         public IReadOnlyList<WindowBase> Windows => _windows;
 
         internal void Register(WindowBase window)
         {
             if (!_windows.Contains(window))
+            {
                 _windows.Add(window);
+                WindowOpened?.Invoke(window);
+            }
 
             Activate(window);
         }
@@ -24,7 +43,12 @@ namespace HackerSimulator.Wasm.Windows
         {
             _windows.Remove(window);
             if (_active == window)
+            {
                 _active = null;
+                ActiveWindowChanged?.Invoke(null);
+            }
+
+            WindowClosed?.Invoke(window);
         }
 
         public void Activate(WindowBase window)
@@ -35,6 +59,7 @@ namespace HackerSimulator.Wasm.Windows
             _active?.InvokeActivated(false);
             _active = window;
             _active.InvokeActivated(true);
+            ActiveWindowChanged?.Invoke(_active);
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow replacing environment dictionaries for pipeline segments
- specify process base in window markup and use code-behind without base
- delete accidentally committed obj files and update `.gitignore`

## Testing
- `dotnet build wasm/HackerSimulator.Wasm/HackerSimulator.Wasm.csproj -c Release`
