### PR TITLE
Enable CSS isolation in wasm components

### DIFF
--- a/wasm/HackerSimulator.Wasm/App/TerminalApp.razor
+++ b/wasm/HackerSimulator.Wasm/App/TerminalApp.razor
@@ -9,29 +9,3 @@
         <input @ref="_inputRef" @bind="_input" @bind:event="oninput" @onkeydown="HandleInputKey" class="input-field" />
     </div>
 </div>
-
-<style>
-.terminal-wrapper {
-    height:100%;
-    width:100%;
-    font-family: monospace;
-    background: #1e1e1e;
-    color: #f0f0f0;
-    padding:4px;
-    box-sizing:border-box;
-    overflow-y:auto;
-}
-.terminal-output {
-    white-space: pre-wrap;
-}
-.input-field {
-    background: transparent;
-    color: inherit;
-    border: none;
-    outline: none;
-    width: calc(100% - 10px);
-}
-.prompt {
-    color: #50fa7b;
-}
-</style>

--- a/wasm/HackerSimulator.Wasm/App/TerminalApp.razor.css
+++ b/wasm/HackerSimulator.Wasm/App/TerminalApp.razor.css
@@ -1,0 +1,23 @@
+.terminal-wrapper {
+    height:100%;
+    width:100%;
+    font-family: monospace;
+    background: #1e1e1e;
+    color: #f0f0f0;
+    padding:4px;
+    box-sizing:border-box;
+    overflow-y:auto;
+}
+.terminal-output {
+    white-space: pre-wrap;
+}
+.input-field {
+    background: transparent;
+    color: inherit;
+    border: none;
+    outline: none;
+    width: calc(100% - 10px);
+}
+.prompt {
+    color: #50fa7b;
+}

--- a/wasm/HackerSimulator.Wasm/Shared/MainLayout.razor
+++ b/wasm/HackerSimulator.Wasm/Shared/MainLayout.razor
@@ -9,18 +9,6 @@
 </div>
 <Taskbar />
 
-<style>
-.container {
-    display: flex;
-    min-height: 100vh;
-    padding-bottom: 40px; /* space for taskbar */
-}
-main {
-    flex: 1;
-    padding: 1rem;
-}
-</style>
-
 @code {
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/wasm/HackerSimulator.Wasm/Shared/MainLayout.razor.css
+++ b/wasm/HackerSimulator.Wasm/Shared/MainLayout.razor.css
@@ -1,0 +1,9 @@
+.container {
+    display: flex;
+    min-height: 100vh;
+    padding-bottom: 40px; /* space for taskbar */
+}
+main {
+    flex: 1;
+    padding: 1rem;
+}

--- a/wasm/HackerSimulator.Wasm/Shared/NavMenu.razor
+++ b/wasm/HackerSimulator.Wasm/Shared/NavMenu.razor
@@ -11,22 +11,3 @@
         <li><NavLink href="settings">Settings</NavLink></li>
     </ul>
 </nav>
-
-<style>
-nav {
-    width: 200px;
-    background-color: #202020;
-    color: white;
-}
-ul {
-    list-style: none;
-    padding: 0;
-}
-li {
-    padding: 0.5rem 1rem;
-}
-li a {
-    color: inherit;
-    text-decoration: none;
-}
-</style>

--- a/wasm/HackerSimulator.Wasm/Shared/NavMenu.razor.css
+++ b/wasm/HackerSimulator.Wasm/Shared/NavMenu.razor.css
@@ -1,0 +1,16 @@
+nav {
+    width: 200px;
+    background-color: #202020;
+    color: white;
+}
+ul {
+    list-style: none;
+    padding: 0;
+}
+li {
+    padding: 0.5rem 1rem;
+}
+li a {
+    color: inherit;
+    text-decoration: none;
+}

--- a/wasm/HackerSimulator.Wasm/Shared/Taskbar.razor
+++ b/wasm/HackerSimulator.Wasm/Shared/Taskbar.razor
@@ -15,41 +15,6 @@
     }
 </div>
 
-<style>
-.taskbar {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    height: 40px;
-    background: #111;
-    display: flex;
-    align-items: center;
-}
-.start-button {
-    margin: 0 4px;
-    height: 32px;
-}
-.task-button {
-    display: flex;
-    align-items: center;
-    margin: 0 2px;
-    padding: 0 6px;
-    height: 32px;
-    background: #222;
-    color: #eee;
-    border: none;
-}
-.task-button.active {
-    background: #444;
-}
-.task-icon {
-    width: 16px;
-    height: 16px;
-    margin-right: 4px;
-}
-</style>
-
 @code {
     private readonly List<WindowBase> _windows = new();
     private WindowBase? _active;

--- a/wasm/HackerSimulator.Wasm/Shared/Taskbar.razor.css
+++ b/wasm/HackerSimulator.Wasm/Shared/Taskbar.razor.css
@@ -1,0 +1,32 @@
+.taskbar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 40px;
+    background: #111;
+    display: flex;
+    align-items: center;
+}
+.start-button {
+    margin: 0 4px;
+    height: 32px;
+}
+.task-button {
+    display: flex;
+    align-items: center;
+    margin: 0 2px;
+    padding: 0 6px;
+    height: 32px;
+    background: #222;
+    color: #eee;
+    border: none;
+}
+.task-button.active {
+    background: #444;
+}
+.task-icon {
+    width: 16px;
+    height: 16px;
+    margin-right: 4px;
+}

--- a/wasm/HackerSimulator.Wasm/Windows/WindowBase.razor
+++ b/wasm/HackerSimulator.Wasm/Windows/WindowBase.razor
@@ -18,13 +18,3 @@
         </CascadingValue>
     </div>
 </div>
-
-<style>
-.hs-window { position:absolute; background:#222; color:#eee; border:1px solid #444; }
-.hs-window-header { background:#333; padding:4px; display:flex; align-items:center; cursor:move; user-select:none; }
-.hs-window-icon { width:16px; height:16px; }
-.hs-window-title { flex:1; margin-left:4px; }
-.hs-window-buttons button { margin-left:4px; }
-.hs-window-content { overflow:auto; height:calc(100% - 30px); padding:4px; }
-.hs-window.active { border-color:#66f; }
-</style>

--- a/wasm/HackerSimulator.Wasm/Windows/WindowBase.razor.css
+++ b/wasm/HackerSimulator.Wasm/Windows/WindowBase.razor.css
@@ -1,0 +1,7 @@
+.hs-window { position:absolute; background:#222; color:#eee; border:1px solid #444; }
+.hs-window-header { background:#333; padding:4px; display:flex; align-items:center; cursor:move; user-select:none; }
+.hs-window-icon { width:16px; height:16px; }
+.hs-window-title { flex:1; margin-left:4px; }
+.hs-window-buttons button { margin-left:4px; }
+.hs-window-content { overflow:auto; height:calc(100% - 30px); padding:4px; }
+.hs-window.active { border-color:#66f; }


### PR DESCRIPTION
## Summary
- refactor inline styles into `.razor.css` files
- remove `<style>` tags from Blazor components

## Testing
- `dotnet build wasm/HackerSimulator.Wasm.sln`
- `npm run build:debug` *(fails: `webpack: not found`)*