### PR TITLE
Add minimal MVC framework to Blazor WASM

### DIFF
--- a/wasm/HackerSimulator.Wasm/HackerSimulator.Wasm.csproj
+++ b/wasm/HackerSimulator.Wasm/HackerSimulator.Wasm.csproj
@@ -3,8 +3,13 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <RazorCompileOnBuild>false</RazorCompileOnBuild>
+    <RazorCompileOnPublish>false</RazorCompileOnPublish>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0-preview.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Update="Views/**/*.cshtml" CopyToOutputDirectory="Always" />
   </ItemGroup>
 </Project>

--- a/wasm/HackerSimulator.Wasm/Program.cs
+++ b/wasm/HackerSimulator.Wasm/Program.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using HackerSimulator.Wasm.Core;
+using HackerSimulator.Wasm.Web;
+using HackerSimulator.Wasm.Web.Controllers;
 
 namespace HackerSimulator.Wasm
 {
@@ -19,10 +21,17 @@ namespace HackerSimulator.Wasm
 
             builder.Services.AddSingleton<NetworkService>();
             builder.Services.AddSingleton<DnsService>();
+            builder.Services.AddSingleton<HackerHttpClient>();
+
+            builder.Services.AddSingleton<HomeController>();
             builder.Services.AddSingleton<Windows.WindowManagerService>();
 
 
-            await builder.Build().RunAsync();
+            var host = builder.Build();
+            // Instantiate controllers so they register with the network
+            _ = host.Services.GetRequiredService<HomeController>();
+
+            await host.RunAsync();
         }
     }
 }

--- a/wasm/HackerSimulator.Wasm/Views/Home/Index.cshtml
+++ b/wasm/HackerSimulator.Wasm/Views/Home/Index.cshtml
@@ -1,0 +1,6 @@
+<html>
+<body>
+<h1>@Model.Title</h1>
+<p>@Model.Message</p>
+</body>
+</html>

--- a/wasm/HackerSimulator.Wasm/Web/Attributes.cs
+++ b/wasm/HackerSimulator.Wasm/Web/Attributes.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace HackerSimulator.Wasm.Web
+{
+    /// <summary>
+    /// Specifies the host name for a controller.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public class HostAttribute : Attribute
+    {
+        public string Path { get; }
+        public HostAttribute(string path = "") => Path = path;
+    }
+
+    /// <summary>
+    /// Base attribute for HTTP method routing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public abstract class HttpMethodAttribute : Attribute
+    {
+        public string Method { get; }
+        public string Path { get; }
+        protected HttpMethodAttribute(string method, string path = "")
+        {
+            Method = method.ToUpperInvariant();
+            Path = path;
+        }
+    }
+
+    public class GetAttribute : HttpMethodAttribute
+    {
+        public GetAttribute(string path = "") : base("GET", path) { }
+    }
+
+    public class PostAttribute : HttpMethodAttribute
+    {
+        public PostAttribute(string path = "") : base("POST", path) { }
+    }
+
+    public class DeleteAttribute : HttpMethodAttribute
+    {
+        public DeleteAttribute(string path = "") : base("DELETE", path) { }
+    }
+
+    // Additional methods could be added here (Put, Patch, etc.)
+}

--- a/wasm/HackerSimulator.Wasm/Web/BaseController.cs
+++ b/wasm/HackerSimulator.Wasm/Web/BaseController.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Web
+{
+    /// <summary>
+    /// Base controller emulating a minimal ASP.NET MVC style API.
+    /// Routes are discovered via attributes when the controller is created.
+    /// </summary>
+    public abstract class BaseController
+    {
+        private readonly Dictionary<string, Dictionary<string, MethodInfo>> _routes = new(StringComparer.OrdinalIgnoreCase);
+
+        protected NetworkService Network { get; }
+        protected DnsService Dns { get; }
+
+        public string Host { get; }
+
+        protected BaseController(NetworkService network, DnsService dns)
+        {
+            Network = network;
+            Dns = dns;
+
+            var hostAttr = GetType().GetCustomAttribute<HostAttribute>();
+            Host = !string.IsNullOrWhiteSpace(hostAttr?.Path)
+                ? hostAttr!.Path
+                : GetType().Name.Replace("Controller", string.Empty);
+
+            Network.RegisterController(Host, this, Dns);
+            DiscoverRoutes();
+        }
+
+        private void DiscoverRoutes()
+        {
+            var methods = GetType().GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            foreach (var method in methods)
+            {
+                if (method.IsSpecialName) continue;
+                var httpAttr = method.GetCustomAttribute<HttpMethodAttribute>();
+                var httpMethod = httpAttr?.Method ?? "GET";
+                var path = httpAttr?.Path;
+                if (string.IsNullOrEmpty(path))
+                    path = method.Name;
+                if (!path.StartsWith("/"))
+                    path = "/" + path;
+
+                if (!_routes.TryGetValue(httpMethod, out var map))
+                {
+                    map = new Dictionary<string, MethodInfo>(StringComparer.OrdinalIgnoreCase);
+                    _routes[httpMethod] = map;
+                }
+                map[path] = method;
+            }
+        }
+
+        public async Task<WebResponse> HandleAsync(WebRequest request)
+        {
+            if (_routes.TryGetValue(request.Method.ToUpperInvariant(), out var map) &&
+                map.TryGetValue(request.Path, out var method))
+            {
+                var result = method.Invoke(this, new object[] { request });
+                if (result is Task<WebResponse> task)
+                    return await task;
+                if (result is WebResponse resp)
+                    return resp;
+                return new WebResponse { Content = result?.ToString() ?? string.Empty };
+            }
+
+            return new ErrorResponse(404, $"No route for {request.Method} {request.Path}");
+        }
+
+        /// <summary>
+        /// Renders a view by name with the provided model using the simple view renderer.
+        /// </summary>
+        protected WebResponse View(string viewName, object model)
+        {
+            var content = SimpleViewRenderer.Render(viewName, model);
+            return new WebResponse { StatusCode = 200, Content = content, Headers = new Dictionary<string, string> { ["Content-Type"] = "text/html" } };
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Web/Controllers/HomeController.cs
+++ b/wasm/HackerSimulator.Wasm/Web/Controllers/HomeController.cs
@@ -1,0 +1,16 @@
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Web.Controllers
+{
+    [Host("localhost")]
+    public class HomeController : BaseController
+    {
+        public HomeController(NetworkService network, DnsService dns) : base(network, dns) { }
+
+        public WebResponse Index(WebRequest request)
+        {
+            var model = new { Title = "Home", Message = "Welcome to Hacker Simulator" };
+            return View("Home/Index", model);
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Web/HackerHttpClient.cs
+++ b/wasm/HackerSimulator.Wasm/Web/HackerHttpClient.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Web
+{
+    /// <summary>
+    /// Simple HttpClient emulation for consuming controller based websites.
+    /// </summary>
+    public class HackerHttpClient
+    {
+        private readonly NetworkService _network;
+        private readonly DnsService _dns;
+
+        public HackerHttpClient(NetworkService network, DnsService dns)
+        {
+            _network = network;
+            _dns = dns;
+        }
+
+        public async Task<WebResponse> SendAsync(string url, string method = "GET", Dictionary<string, string>? headers = null, string? body = null)
+        {
+            var uri = new Uri(url);
+            var host = uri.Host;
+            if (!_dns.Resolve(host)?.Equals(host) == true)
+            {
+                var ip = _dns.Resolve(host);
+                if (ip == null)
+                    throw new Exception($"Unable to resolve host {host}");
+            }
+
+            var controller = _network.GetController(host);
+            if (controller == null)
+                return new ErrorResponse(404, $"Host {host} not found");
+
+            var request = new WebRequest
+            {
+                Method = method.ToUpperInvariant(),
+                Path = string.IsNullOrEmpty(uri.AbsolutePath) ? "/" : uri.AbsolutePath,
+                Headers = headers ?? new Dictionary<string, string>(),
+                Body = body
+            };
+
+            if (!string.IsNullOrEmpty(uri.Query))
+            {
+                foreach (var kv in uri.Query.TrimStart('?').Split('&', StringSplitOptions.RemoveEmptyEntries))
+                {
+                    var parts = kv.Split('=', 2);
+                    request.Query[parts[0]] = parts.Length > 1 ? parts[1] : string.Empty;
+                }
+            }
+
+            return await controller.HandleAsync(request);
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Web/SimpleViewRenderer.cs
+++ b/wasm/HackerSimulator.Wasm/Web/SimpleViewRenderer.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace HackerSimulator.Wasm.Web
+{
+    /// <summary>
+    /// Extremely simple view renderer used for demonstration purposes.
+    /// Looks for views under the Views folder relative to the application base path
+    /// and performs placeholder replacement using @Model.Property syntax.
+    /// </summary>
+    public static class SimpleViewRenderer
+    {
+        public static string Render(string viewPath, object model)
+        {
+            var basePath = Path.Combine(AppContext.BaseDirectory, "Views");
+            var full = Path.Combine(basePath, viewPath + ".cshtml");
+            if (!File.Exists(full))
+                return $"<!-- View {viewPath} not found -->";
+
+            var template = File.ReadAllText(full);
+            var type = model.GetType();
+            foreach (var prop in type.GetProperties(BindingFlags.Instance | BindingFlags.Public))
+            {
+                var placeholder = "@Model." + prop.Name;
+                var value = prop.GetValue(model)?.ToString() ?? string.Empty;
+                template = template.Replace(placeholder, value);
+            }
+            return template;
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Web/WebRequest.cs
+++ b/wasm/HackerSimulator.Wasm/Web/WebRequest.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace HackerSimulator.Wasm.Web
+{
+    /// <summary>
+    /// Simplified web request representation used by the MVC emulation.
+    /// </summary>
+    public class WebRequest
+    {
+        public string Method { get; set; } = "GET";
+        public string Path { get; set; } = "/";
+        public Dictionary<string, string> Query { get; set; } = new();
+        public Dictionary<string, string> Headers { get; set; } = new();
+        public string? Body { get; set; }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Web/WebResponse.cs
+++ b/wasm/HackerSimulator.Wasm/Web/WebResponse.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+
+namespace HackerSimulator.Wasm.Web
+{
+    /// <summary>
+    /// Basic web response used by the MVC emulation.
+    /// </summary>
+    public class WebResponse
+    {
+        public int StatusCode { get; set; } = 200;
+        public Dictionary<string, string> Headers { get; set; } = new();
+        public string Content { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Convenience response for returning an error.
+    /// </summary>
+    public class ErrorResponse : WebResponse
+    {
+        public ErrorResponse(int status, string message)
+        {
+            StatusCode = status;
+            Content = message;
+        }
+    }
+
+    /// <summary>
+    /// Redirect response.
+    /// </summary>
+    public class RedirectResponse : WebResponse
+    {
+        public string RedirectUrl { get; }
+        public RedirectResponse(string url, bool permanent = false)
+        {
+            RedirectUrl = url;
+            StatusCode = permanent ? 301 : 302;
+            Headers["Location"] = url;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement basic MVC infrastructure for the WASM project
- introduce `BaseController`, routing attributes and a simple view renderer
- extend `NetworkService` to register controller hosts
- add `HackerHttpClient` for consuming controller-based sites
- example `HomeController` and Razor-like view

## Testing
- `dotnet build wasm/HackerSimulator.Wasm/HackerSimulator.Wasm.csproj`