### PR TITLE
Refactor process hierarchy with command base

### DIFF
--- a/wasm/HackerSimulator.Wasm/Commands/CommandBase.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/CommandBase.cs
@@ -10,11 +10,11 @@ namespace HackerSimulator.Wasm.Commands
     /// When started outside of a TerminalProcess, they will run inside a new
     /// terminal instance.
     /// </summary>
-    public abstract class Executable : ProcessBase, ICommandModule
+    public abstract class CommandBase : ProcessBase, ICommandModule
     {
         private readonly ShellService _shell;
 
-        protected Executable(string name, ShellService shell) : base(name)
+        protected CommandBase(string name, ShellService shell, KernelService kernel) : base(name, kernel)
         {
             _shell = shell;
         }

--- a/wasm/HackerSimulator.Wasm/Commands/EchoCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/EchoCommand.cs
@@ -6,9 +6,9 @@ namespace HackerSimulator.Wasm.Commands
     /// <summary>
     /// Simple echo command used for testing pipeline support.
     /// </summary>
-    public class EchoCommand : Executable
+    public class EchoCommand : CommandBase
     {
-        public EchoCommand(ShellService shell) : base("echo", shell) { }
+        public EchoCommand(ShellService shell, KernelService kernel) : base("echo", shell, kernel) { }
 
         public override string Description => "Echo the input arguments";
         public override string Usage => "echo [text]";

--- a/wasm/HackerSimulator.Wasm/Commands/UpperCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/UpperCommand.cs
@@ -6,9 +6,9 @@ namespace HackerSimulator.Wasm.Commands
     /// <summary>
     /// Reads from stdin and writes uppercase output.
     /// </summary>
-    public class UpperCommand : Executable
+    public class UpperCommand : CommandBase
     {
-        public UpperCommand(ShellService shell) : base("upper", shell) { }
+        public UpperCommand(ShellService shell, KernelService kernel) : base("upper", shell, kernel) { }
 
         public override string Description => "Convert input to upper case";
         public override string Usage => "upper";

--- a/wasm/HackerSimulator.Wasm/Core/IExecutable.cs
+++ b/wasm/HackerSimulator.Wasm/Core/IExecutable.cs
@@ -1,0 +1,13 @@
+namespace HackerSimulator.Wasm.Core
+{
+    /// <summary>
+    /// Represents a runnable entity that can be launched by the shell.
+    /// </summary>
+    public interface IExecutable
+    {
+        /// <summary>
+        /// Unique name of the executable.
+        /// </summary>
+        string Name { get; }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Core/KernelService.cs
+++ b/wasm/HackerSimulator.Wasm/Core/KernelService.cs
@@ -11,13 +11,26 @@ namespace HackerSimulator.Wasm.Core
 
         public IReadOnlyList<ProcessInfo> Processes => _processes;
 
-        public Task RunProcess(ProcessBase process, string[] args)
+        public ProcessInfo RegisterProcess(ProcessBase process)
         {
             var cts = new CancellationTokenSource();
             var info = new ProcessInfo(process, cts);
             _processes.Add(info);
-            info.Start(args);
-            return Task.CompletedTask;
+            return info;
+        }
+
+        public void UnregisterProcess(System.Guid id)
+        {
+            var info = _processes.FirstOrDefault(p => p.Process.Id == id);
+            if (info != null)
+            {
+                _processes.Remove(info);
+            }
+        }
+
+        public Task RunProcess(ProcessBase process, string[] args)
+        {
+            return process.StartAsync(args);
         }
 
         public bool KillProcess(System.Guid id)

--- a/wasm/HackerSimulator.Wasm/Core/ProcessBase.cs
+++ b/wasm/HackerSimulator.Wasm/Core/ProcessBase.cs
@@ -5,9 +5,16 @@ using Microsoft.AspNetCore.Components;
 
 namespace HackerSimulator.Wasm.Core
 {
-    public abstract class ProcessBase : ComponentBase
+    public abstract class ProcessBase : ComponentBase, IExecutable
     {
         protected ProcessBase(string name) => Name = name;
+        protected ProcessBase(string name, KernelService kernel) : this(name)
+        {
+            Kernel = kernel;
+        }
+
+        [Inject]
+        protected KernelService Kernel { get; set; } = default!;
 
         public Guid Id { get; } = Guid.NewGuid();
         public string Name { get; }
@@ -17,19 +24,30 @@ namespace HackerSimulator.Wasm.Core
 
         public Task StartAsync(string[] args, CancellationToken token = default)
         {
+            if (Kernel is null)
+                throw new InvalidOperationException("Kernel service not configured.");
+
             State = ProcessState.Running;
+
+            var info = Kernel.RegisterProcess(this);
+            var cts = info.CancellationTokenSource;
+            if (token != default)
+                cts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, token);
+
             _runningTask = Task.Run(async () =>
             {
                 try
                 {
-                    await RunAsync(args, token);
+                    await RunAsync(args, cts.Token);
                 }
                 finally
                 {
                     State = ProcessState.Exited;
+                    Kernel.UnregisterProcess(Id);
                 }
-            }, token);
+            }, cts.Token);
 
+            info.AttachTask(_runningTask);
             return _runningTask;
         }
 

--- a/wasm/HackerSimulator.Wasm/Core/ProcessInfo.cs
+++ b/wasm/HackerSimulator.Wasm/Core/ProcessInfo.cs
@@ -30,8 +30,14 @@ namespace HackerSimulator.Wasm.Core
 
         public void Start(string[] args)
         {
-            Task = Process.StartAsync(args, CancellationTokenSource.Token);
-            Task.ContinueWith(_ =>
+            var task = Process.StartAsync(args, CancellationTokenSource.Token);
+            AttachTask(task);
+        }
+
+        internal void AttachTask(Task task)
+        {
+            Task = task;
+            task.ContinueWith(_ =>
             {
                 EndTime = DateTime.UtcNow;
                 EndMemory = GC.GetTotalMemory(false);

--- a/wasm/HackerSimulator.Wasm/Core/ShellService.cs
+++ b/wasm/HackerSimulator.Wasm/Core/ShellService.cs
@@ -37,8 +37,8 @@ namespace HackerSimulator.Wasm.Core
 
         private void RegisterBuiltInCommands()
         {
-            RegisterCommand(new EchoCommand(this));
-            RegisterCommand(new UpperCommand(this));
+            RegisterCommand(new EchoCommand(this, _kernel));
+            RegisterCommand(new UpperCommand(this, _kernel));
         }
 
         public void RegisterCommand(ICommandModule command)
@@ -59,9 +59,9 @@ namespace HackerSimulator.Wasm.Core
                 return;
             }
 
-            // If the target process is an Executable and sender isn't a terminal,
+            // If the target process is a command and sender isn't a terminal,
             // launch it inside a new terminal instance.
-            if (typeof(Executable).IsAssignableFrom(type) && sender is not Processes.TerminalProcess)
+            if (typeof(CommandBase).IsAssignableFrom(type) && sender is not Processes.TerminalProcess)
             {
                 var terminalArgs = new string[] { name }.Concat(args).ToArray();
                 await Run("terminal", terminalArgs, sender);
@@ -69,7 +69,7 @@ namespace HackerSimulator.Wasm.Core
             }
 
             var process = (ProcessBase)ActivatorUtilities.CreateInstance(_provider, type);
-            await _kernel.RunProcess(process, args);
+            await process.StartAsync(args);
         }
     }
 }

--- a/wasm/HackerSimulator.Wasm/Processes/SystemProcess.cs
+++ b/wasm/HackerSimulator.Wasm/Processes/SystemProcess.cs
@@ -12,7 +12,7 @@ namespace HackerSimulator.Wasm.Processes
     {
         private readonly ShellService _shell;
 
-        public SystemProcess(ShellService shell) : base("system")
+        public SystemProcess(ShellService shell, KernelService kernel) : base("system", kernel)
         {
             _shell = shell;
         }

--- a/wasm/HackerSimulator.Wasm/Processes/TerminalProcess.cs
+++ b/wasm/HackerSimulator.Wasm/Processes/TerminalProcess.cs
@@ -10,7 +10,7 @@ namespace HackerSimulator.Wasm.Processes
     {
         private readonly ShellService _shell;
 
-        public TerminalProcess(ShellService shell) : base("terminal")
+        public TerminalProcess(ShellService shell, KernelService kernel) : base("terminal", kernel)
         {
             _shell = shell;
         }


### PR DESCRIPTION
## Summary
- introduce `IExecutable` so all processes expose their name
- rename `Executable` to `CommandBase` and derive from `ProcessBase`
- make `ProcessBase` implement `IExecutable`
- update `ShellService` logic to detect `CommandBase` processes

## Testing
- `dotnet build wasm/HackerSimulator.Wasm/HackerSimulator.Wasm.csproj -v q`
