### PR TITLE
Add basic linux command implementations

### DIFF
--- a/wasm/HackerSimulator.Wasm/Commands/CommandProcessor.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/CommandProcessor.cs
@@ -96,5 +96,12 @@ namespace HackerSimulator.Wasm.Commands
             if (current.Length > 0)
                 yield return current;
         }
+
+        public IEnumerable<ICommandModule> GetCommands() => _commands.Values;
+        public ICommandModule? GetCommand(string name)
+        {
+            _commands.TryGetValue(name.ToLowerInvariant(), out var cmd);
+            return cmd;
+        }
     }
 }

--- a/wasm/HackerSimulator.Wasm/Commands/linux/AddAliasCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/AddAliasCommand.cs
@@ -1,0 +1,32 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class AddAliasCommand : CommandBase
+    {
+        private readonly AliasService _aliases;
+        public AddAliasCommand(ShellService shell, KernelService kernel, AliasService aliases) : base("addalias", shell, kernel)
+        {
+            _aliases = aliases;
+        }
+
+        public override string Description => "Create a filesystem alias";
+        public override string Usage => "addalias <alias> <path>";
+
+        protected override Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            if (args.Length < 2)
+            {
+                context.Stderr.WriteLine($"Usage: {Usage}");
+                return Task.CompletedTask;
+            }
+
+            var alias = args[0];
+            var target = args[1];
+            _aliases.Register(alias, target);
+            context.Stdout.WriteLine($"Alias {alias} -> {target} added");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/AliasCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/AliasCommand.cs
@@ -1,0 +1,26 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class AliasCommand : CommandBase
+    {
+        private readonly AliasService _aliases;
+        public AliasCommand(ShellService shell, KernelService kernel, AliasService aliases) : base("alias", shell, kernel)
+        {
+            _aliases = aliases;
+        }
+
+        public override string Description => "List registered aliases";
+        public override string Usage => "alias";
+
+        protected override Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            foreach (var (alias, target) in _aliases.GetAll())
+            {
+                context.Stdout.WriteLine($"{alias} -> {target}");
+            }
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/CatCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/CatCommand.cs
@@ -1,0 +1,41 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class CatCommand : CommandBase
+    {
+        private readonly FileSystemService _fs;
+        public CatCommand(ShellService shell, KernelService kernel, FileSystemService fs) : base("cat", shell, kernel)
+        {
+            _fs = fs;
+        }
+
+        public override string Description => "Concatenate files";
+        public override string Usage => "cat <file>...";
+
+        protected override async Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            if (args.Length == 0)
+            {
+                context.Stderr.WriteLine("cat: missing file operand");
+                return;
+            }
+
+            var cwd = context.Env.TryGetValue("PWD", out var c) ? c : "/";
+            foreach (var file in args)
+            {
+                var path = _fs.ResolvePath(file, cwd);
+                try
+                {
+                    var content = await _fs.ReadFile(path);
+                    context.Stdout.WriteLine(content);
+                }
+                catch (System.Exception ex)
+                {
+                    context.Stderr.WriteLine($"cat: {file}: {ex.Message}");
+                }
+            }
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/CdCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/CdCommand.cs
@@ -1,0 +1,38 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class CdCommand : CommandBase
+    {
+        private readonly FileSystemService _fs;
+        public CdCommand(ShellService shell, KernelService kernel, FileSystemService fs) : base("cd", shell, kernel)
+        {
+            _fs = fs;
+        }
+
+        public override string Description => "Change directory";
+        public override string Usage => "cd <dir>";
+
+        protected override async Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            var cwd = context.Env.TryGetValue("PWD", out var c) ? c : "/";
+            var target = args.Length > 0 ? args[0] : "~";
+            var path = _fs.ResolvePath(target, cwd);
+            try
+            {
+                var stat = await _fs.Stat(path);
+                if (!stat.IsDirectory)
+                {
+                    context.Stderr.WriteLine("cd: not a directory");
+                    return;
+                }
+                context.Env["PWD"] = path;
+            }
+            catch (System.Exception ex)
+            {
+                context.Stderr.WriteLine($"cd: {ex.Message}");
+            }
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/ChmodCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/ChmodCommand.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class ChmodCommand : CommandBase
+    {
+        public ChmodCommand(ShellService shell, KernelService kernel) : base("chmod", shell, kernel) { }
+
+        public override string Description => "Change file mode bits";
+        public override string Usage => "chmod MODE FILE";
+
+        protected override Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            context.Stderr.WriteLine("chmod: operation not supported");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/ClearCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/ClearCommand.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class ClearCommand : CommandBase
+    {
+        public ClearCommand(ShellService shell, KernelService kernel) : base("clear", shell, kernel) { }
+
+        public override string Description => "Clear the screen";
+        public override string Usage => "clear";
+
+        protected override Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            context.Stdout.Write("\x1B[2J\x1B[0f");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/CpCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/CpCommand.cs
@@ -1,0 +1,44 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class CpCommand : CommandBase
+    {
+        private readonly FileSystemService _fs;
+        public CpCommand(ShellService shell, KernelService kernel, FileSystemService fs) : base("cp", shell, kernel)
+        {
+            _fs = fs;
+        }
+
+        public override string Description => "Copy files";
+        public override string Usage => "cp SOURCE DEST";
+
+        protected override async Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            if (args.Length < 2)
+            {
+                context.Stderr.WriteLine($"Usage: {Usage}");
+                return;
+            }
+
+            var cwd = context.Env.TryGetValue("PWD", out var c) ? c : "/";
+            var dest = _fs.ResolvePath(args[^1], cwd);
+            for (int i = 0; i < args.Length - 1; i++)
+            {
+                var src = _fs.ResolvePath(args[i], cwd);
+                var target = dest;
+                if (args.Length > 2)
+                    target = dest.TrimEnd('/') + "/" + System.IO.Path.GetFileName(src);
+                try
+                {
+                    await _fs.Copy(src, target);
+                }
+                catch (System.Exception ex)
+                {
+                    context.Stderr.WriteLine($"cp: {args[i]}: {ex.Message}");
+                }
+            }
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/CurlCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/CurlCommand.cs
@@ -1,0 +1,38 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+using HackerSimulator.Wasm.Web;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class CurlCommand : CommandBase
+    {
+        private readonly HackerHttpClient _http;
+        public CurlCommand(ShellService shell, KernelService kernel, HackerHttpClient http) : base("curl", shell, kernel)
+        {
+            _http = http;
+        }
+
+        public override string Description => "Transfer a URL";
+        public override string Usage => "curl <url>";
+
+        protected override async Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            if (args.Length == 0)
+            {
+                context.Stderr.WriteLine($"Usage: {Usage}");
+                return;
+            }
+
+            var url = args[0];
+            try
+            {
+                var resp = await _http.SendAsync(url);
+                context.Stdout.WriteLine(resp.Content);
+            }
+            catch (System.Exception ex)
+            {
+                context.Stderr.WriteLine($"curl: {ex.Message}");
+            }
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/DiffCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/DiffCommand.cs
@@ -1,0 +1,51 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class DiffCommand : CommandBase
+    {
+        private readonly FileSystemService _fs;
+        public DiffCommand(ShellService shell, KernelService kernel, FileSystemService fs) : base("diff", shell, kernel)
+        {
+            _fs = fs;
+        }
+
+        public override string Description => "Compare files";
+        public override string Usage => "diff FILE1 FILE2";
+
+        protected override async Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            if (args.Length < 2)
+            {
+                context.Stderr.WriteLine($"Usage: {Usage}");
+                return;
+            }
+            var cwd = context.Env.TryGetValue("PWD", out var c) ? c : "/";
+            var p1 = _fs.ResolvePath(args[0], cwd);
+            var p2 = _fs.ResolvePath(args[1], cwd);
+            try
+            {
+                var t1 = await _fs.ReadFile(p1);
+                var t2 = await _fs.ReadFile(p2);
+                var a1 = t1.Split('\n');
+                var a2 = t2.Split('\n');
+                var max = System.Math.Max(a1.Length, a2.Length);
+                for (int i = 0; i < max; i++)
+                {
+                    var s1 = i < a1.Length ? a1[i] : string.Empty;
+                    var s2 = i < a2.Length ? a2[i] : string.Empty;
+                    if (s1 != s2)
+                    {
+                        context.Stdout.WriteLine($"-{s1}");
+                        context.Stdout.WriteLine($"+{s2}");
+                    }
+                }
+            }
+            catch (System.Exception ex)
+            {
+                context.Stderr.WriteLine($"diff: {ex.Message}");
+            }
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/EchoCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/EchoCommand.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class EchoCommand : CommandBase
+    {
+        public EchoCommand(ShellService shell, KernelService kernel) : base("echo", shell, kernel) { }
+
+        public override string Description => "Display text";
+        public override string Usage => "echo [text]";
+
+        protected override Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            var output = string.Join(' ', args);
+            context.Stdout.WriteLine(output);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/FindCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/FindCommand.cs
@@ -1,0 +1,42 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class FindCommand : CommandBase
+    {
+        private readonly FileSystemService _fs;
+        public FindCommand(ShellService shell, KernelService kernel, FileSystemService fs) : base("find", shell, kernel)
+        {
+            _fs = fs;
+        }
+
+        public override string Description => "Search for files";
+        public override string Usage => "find [path]";
+
+        protected override async Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            var cwd = context.Env.TryGetValue("PWD", out var c) ? c : "/";
+            var start = args.Length > 0 ? args[0] : ".";
+            var root = _fs.ResolvePath(start, cwd);
+            await Recurse(root);
+
+            async Task Recurse(string path)
+            {
+                context.Stdout.WriteLine(path);
+                try
+                {
+                    var entries = await _fs.ReadDirectory(path);
+                    foreach (var e in entries)
+                    {
+                        if (e.IsDirectory)
+                            await Recurse(path.TrimEnd('/') + "/" + e.Name);
+                        else
+                            context.Stdout.WriteLine(path.TrimEnd('/') + "/" + e.Name);
+                    }
+                }
+                catch { }
+            }
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/GrepCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/GrepCommand.cs
@@ -1,0 +1,46 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class GrepCommand : CommandBase
+    {
+        private readonly FileSystemService _fs;
+        public GrepCommand(ShellService shell, KernelService kernel, FileSystemService fs) : base("grep", shell, kernel)
+        {
+            _fs = fs;
+        }
+
+        public override string Description => "Search text";
+        public override string Usage => "grep PATTERN FILE";
+
+        protected override async Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            if (args.Length < 2)
+            {
+                context.Stderr.WriteLine($"Usage: {Usage}");
+                return;
+            }
+            var pattern = args[0];
+            var cwd = context.Env.TryGetValue("PWD", out var c) ? c : "/";
+            for (int i = 1; i < args.Length; i++)
+            {
+                var file = _fs.ResolvePath(args[i], cwd);
+                try
+                {
+                    var text = await _fs.ReadFile(file);
+                    var lines = text.Split('\n');
+                    for (int ln = 0; ln < lines.Length; ln++)
+                    {
+                        if (lines[ln].Contains(pattern))
+                            context.Stdout.WriteLine($"{ln + 1}:{lines[ln]}");
+                    }
+                }
+                catch (System.Exception ex)
+                {
+                    context.Stderr.WriteLine($"grep: {args[i]}: {ex.Message}");
+                }
+            }
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/HeadCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/HeadCommand.cs
@@ -1,0 +1,39 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class HeadCommand : CommandBase
+    {
+        private readonly FileSystemService _fs;
+        public HeadCommand(ShellService shell, KernelService kernel, FileSystemService fs) : base("head", shell, kernel)
+        {
+            _fs = fs;
+        }
+
+        public override string Description => "Output start of files";
+        public override string Usage => "head FILE";
+
+        protected override async Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            if (args.Length == 0)
+            {
+                context.Stderr.WriteLine($"Usage: {Usage}");
+                return;
+            }
+            var cwd = context.Env.TryGetValue("PWD", out var c) ? c : "/";
+            var path = _fs.ResolvePath(args[0], cwd);
+            try
+            {
+                var content = await _fs.ReadFile(path);
+                var lines = content.Split('\n');
+                for (int i = 0; i < System.Math.Min(10, lines.Length); i++)
+                    context.Stdout.WriteLine(lines[i]);
+            }
+            catch (System.Exception ex)
+            {
+                context.Stderr.WriteLine($"head: {ex.Message}");
+            }
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/HelpCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/HelpCommand.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class HelpCommand : CommandBase
+    {
+        public HelpCommand(ShellService shell, KernelService kernel) : base("help", shell, kernel) { }
+
+        public override string Description => "Display available commands";
+        public override string Usage => "help";
+
+        protected override Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            foreach (var cmd in Shell.GetCommands())
+            {
+                context.Stdout.WriteLine($"{cmd.Name}\t{cmd.Description}");
+            }
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/KillCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/KillCommand.cs
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class KillCommand : CommandBase
+    {
+        public KillCommand(ShellService shell, KernelService kernel) : base("kill", shell, kernel) { }
+
+        public override string Description => "Terminate a process";
+        public override string Usage => "kill <pid>";
+
+        protected override Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            if (args.Length == 0 || !System.Guid.TryParse(args[0], out var pid))
+            {
+                context.Stderr.WriteLine($"Usage: {Usage}");
+                return Task.CompletedTask;
+            }
+            if (Kernel.KillProcess(pid))
+                context.Stdout.WriteLine("Process terminated");
+            else
+                context.Stderr.WriteLine("Process not found");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/LaunchCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/LaunchCommand.cs
@@ -1,0 +1,25 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class LaunchCommand : CommandBase
+    {
+        public LaunchCommand(ShellService shell, KernelService kernel) : base("launch", shell, kernel) { }
+
+        public override string Description => "Launch a process";
+        public override string Usage => "launch <process> [args...]";
+
+        protected override async Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            if (args.Length == 0)
+            {
+                context.Stderr.WriteLine($"Usage: {Usage}");
+                return;
+            }
+            var name = args[0];
+            var pArgs = args.Length > 1 ? args[1..] : System.Array.Empty<string>();
+            await Shell.Run(name, pArgs, null);
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/LsCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/LsCommand.cs
@@ -1,0 +1,35 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class LsCommand : CommandBase
+    {
+        private readonly FileSystemService _fs;
+        public LsCommand(ShellService shell, KernelService kernel, FileSystemService fs) : base("ls", shell, kernel)
+        {
+            _fs = fs;
+        }
+
+        public override string Description => "List directory contents";
+        public override string Usage => "ls [path]";
+
+        protected override async Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            var cwd = context.Env.TryGetValue("PWD", out var c) ? c : "/";
+            var path = args.Length > 0 ? _fs.ResolvePath(args[0], cwd) : cwd;
+            try
+            {
+                var entries = await _fs.ReadDirectory(path);
+                foreach (var e in entries)
+                {
+                    context.Stdout.WriteLine(e.Name + (e.IsDirectory ? "/" : string.Empty));
+                }
+            }
+            catch (System.Exception ex)
+            {
+                context.Stderr.WriteLine($"ls: {ex.Message}");
+            }
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/ManCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/ManCommand.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class ManCommand : CommandBase
+    {
+        public ManCommand(ShellService shell, KernelService kernel) : base("man", shell, kernel) { }
+
+        public override string Description => "Display command help";
+        public override string Usage => "man <command>";
+
+        protected override Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            if (args.Length == 0)
+            {
+                context.Stderr.WriteLine("man: missing command");
+                return Task.CompletedTask;
+            }
+            var cmd = Shell.GetCommand(args[0]);
+            if (cmd == null)
+            {
+                context.Stderr.WriteLine($"man: {args[0]}: command not found");
+                return Task.CompletedTask;
+            }
+            context.Stdout.WriteLine($"{cmd.Name} - {cmd.Description}\nUsage: {cmd.Usage}");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/MkdirCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/MkdirCommand.cs
@@ -1,0 +1,36 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class MkdirCommand : CommandBase
+    {
+        private readonly FileSystemService _fs;
+        public MkdirCommand(ShellService shell, KernelService kernel, FileSystemService fs) : base("mkdir", shell, kernel)
+        {
+            _fs = fs;
+        }
+
+        public override string Description => "Create directories";
+        public override string Usage => "mkdir DIR";
+
+        protected override async Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            if (args.Length == 0)
+            {
+                context.Stderr.WriteLine($"Usage: {Usage}");
+                return;
+            }
+            var cwd = context.Env.TryGetValue("PWD", out var c) ? c : "/";
+            var path = _fs.ResolvePath(args[0], cwd);
+            try
+            {
+                await _fs.CreateDirectory(path);
+            }
+            catch (System.Exception ex)
+            {
+                context.Stderr.WriteLine($"mkdir: {ex.Message}");
+            }
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/MvCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/MvCommand.cs
@@ -1,0 +1,37 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class MvCommand : CommandBase
+    {
+        private readonly FileSystemService _fs;
+        public MvCommand(ShellService shell, KernelService kernel, FileSystemService fs) : base("mv", shell, kernel)
+        {
+            _fs = fs;
+        }
+
+        public override string Description => "Move/rename files";
+        public override string Usage => "mv SOURCE DEST";
+
+        protected override async Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            if (args.Length < 2)
+            {
+                context.Stderr.WriteLine($"Usage: {Usage}");
+                return;
+            }
+            var cwd = context.Env.TryGetValue("PWD", out var c) ? c : "/";
+            var src = _fs.ResolvePath(args[0], cwd);
+            var dest = _fs.ResolvePath(args[1], cwd);
+            try
+            {
+                await _fs.Move(src, dest);
+            }
+            catch (System.Exception ex)
+            {
+                context.Stderr.WriteLine($"mv: {ex.Message}");
+            }
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/NmapCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/NmapCommand.cs
@@ -1,0 +1,40 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class NmapCommand : CommandBase
+    {
+        private readonly NetworkService _network;
+        private readonly DnsService _dns;
+        public NmapCommand(ShellService shell, KernelService kernel, NetworkService network, DnsService dns) : base("nmap", shell, kernel)
+        {
+            _network = network;
+            _dns = dns;
+        }
+
+        public override string Description => "Network scanner";
+        public override string Usage => "nmap <host>";
+
+        protected override Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            if (args.Length == 0)
+            {
+                context.Stderr.WriteLine($"Usage: {Usage}");
+                return Task.CompletedTask;
+            }
+            var host = args[0];
+            var ip = _dns.Resolve(host) ?? host;
+            var info = _network.ScanHost(ip);
+            if (info == null)
+            {
+                context.Stderr.WriteLine("Host not found");
+                return Task.CompletedTask;
+            }
+            context.Stdout.WriteLine($"Nmap scan report for {host} ({ip})");
+            foreach (var p in info.Ports)
+                context.Stdout.WriteLine($"{p.Port}/tcp\t{p.State}\t{p.Service?.Name}");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/PingCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/PingCommand.cs
@@ -1,0 +1,38 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class PingCommand : CommandBase
+    {
+        private readonly NetworkService _network;
+        private readonly DnsService _dns;
+        public PingCommand(ShellService shell, KernelService kernel, NetworkService network, DnsService dns) : base("ping", shell, kernel)
+        {
+            _network = network;
+            _dns = dns;
+        }
+
+        public override string Description => "Send ICMP ECHO_REQUEST";
+        public override string Usage => "ping <host>";
+
+        protected override Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            if (args.Length == 0)
+            {
+                context.Stderr.WriteLine($"Usage: {Usage}");
+                return Task.CompletedTask;
+            }
+            var host = args[0];
+            var ip = _dns.Resolve(host) ?? host;
+            var info = _network.GetHostByIp(ip);
+            if (info == null || !info.IsUp)
+            {
+                context.Stderr.WriteLine("Host unreachable");
+                return Task.CompletedTask;
+            }
+            context.Stdout.WriteLine($"Reply from {ip}: time={info.Latency}ms");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/PsCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/PsCommand.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class PsCommand : CommandBase
+    {
+        public PsCommand(ShellService shell, KernelService kernel) : base("ps", shell, kernel) { }
+
+        public override string Description => "List processes";
+        public override string Usage => "ps";
+
+        protected override Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            foreach (var p in Kernel.Processes)
+            {
+                context.Stdout.WriteLine($"{p.Process.Id}\t{p.Process.Name}\t{p.Process.State}");
+            }
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/PwdCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/PwdCommand.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class PwdCommand : CommandBase
+    {
+        public PwdCommand(ShellService shell, KernelService kernel) : base("pwd", shell, kernel) { }
+
+        public override string Description => "Print working directory";
+        public override string Usage => "pwd";
+
+        protected override Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            if (context.Env.TryGetValue("PWD", out var cwd))
+                context.Stdout.WriteLine(cwd);
+            else
+                context.Stdout.WriteLine("/");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/RmAliasCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/RmAliasCommand.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class RmAliasCommand : CommandBase
+    {
+        private readonly AliasService _aliases;
+        public RmAliasCommand(ShellService shell, KernelService kernel, AliasService aliases) : base("rmalias", shell, kernel)
+        {
+            _aliases = aliases;
+        }
+
+        public override string Description => "Remove an alias";
+        public override string Usage => "rmalias <alias>";
+
+        protected override Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            if (args.Length == 0)
+            {
+                context.Stderr.WriteLine($"Usage: {Usage}");
+                return Task.CompletedTask;
+            }
+            if (_aliases.Unregister(args[0]))
+                context.Stdout.WriteLine("Alias removed");
+            else
+                context.Stderr.WriteLine("Alias not found");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/RmCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/RmCommand.cs
@@ -1,0 +1,39 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class RmCommand : CommandBase
+    {
+        private readonly FileSystemService _fs;
+        public RmCommand(ShellService shell, KernelService kernel, FileSystemService fs) : base("rm", shell, kernel)
+        {
+            _fs = fs;
+        }
+
+        public override string Description => "Remove files";
+        public override string Usage => "rm FILE";
+
+        protected override async Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            if (args.Length == 0)
+            {
+                context.Stderr.WriteLine($"Usage: {Usage}");
+                return;
+            }
+            var cwd = context.Env.TryGetValue("PWD", out var c) ? c : "/";
+            foreach (var arg in args)
+            {
+                var path = _fs.ResolvePath(arg, cwd);
+                try
+                {
+                    await _fs.DeleteEntry(path);
+                }
+                catch (System.Exception ex)
+                {
+                    context.Stderr.WriteLine($"rm: {ex.Message}");
+                }
+            }
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/SortCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/SortCommand.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class SortCommand : CommandBase
+    {
+        public SortCommand(ShellService shell, KernelService kernel) : base("sort", shell, kernel) { }
+
+        public override string Description => "Sort lines of text";
+        public override string Usage => "sort";
+
+        protected override async Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            var input = await context.Stdin.ReadToEndAsync();
+            var lines = input.Split('\n', System.StringSplitOptions.RemoveEmptyEntries);
+            System.Array.Sort(lines, System.StringComparer.Ordinal);
+            foreach (var line in lines)
+                context.Stdout.WriteLine(line);
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/TailCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/TailCommand.cs
@@ -1,0 +1,40 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class TailCommand : CommandBase
+    {
+        private readonly FileSystemService _fs;
+        public TailCommand(ShellService shell, KernelService kernel, FileSystemService fs) : base("tail", shell, kernel)
+        {
+            _fs = fs;
+        }
+
+        public override string Description => "Output end of files";
+        public override string Usage => "tail FILE";
+
+        protected override async Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            if (args.Length == 0)
+            {
+                context.Stderr.WriteLine($"Usage: {Usage}");
+                return;
+            }
+            var cwd = context.Env.TryGetValue("PWD", out var c) ? c : "/";
+            var path = _fs.ResolvePath(args[0], cwd);
+            try
+            {
+                var content = await _fs.ReadFile(path);
+                var lines = content.Split('\n');
+                int start = System.Math.Max(lines.Length - 10, 0);
+                for (int i = start; i < lines.Length; i++)
+                    context.Stdout.WriteLine(lines[i]);
+            }
+            catch (System.Exception ex)
+            {
+                context.Stderr.WriteLine($"tail: {ex.Message}");
+            }
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/TouchCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/TouchCommand.cs
@@ -1,0 +1,47 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class TouchCommand : CommandBase
+    {
+        private readonly FileSystemService _fs;
+        public TouchCommand(ShellService shell, KernelService kernel, FileSystemService fs) : base("touch", shell, kernel)
+        {
+            _fs = fs;
+        }
+
+        public override string Description => "Update file timestamps";
+        public override string Usage => "touch FILE";
+
+        protected override async Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            if (args.Length == 0)
+            {
+                context.Stderr.WriteLine($"Usage: {Usage}");
+                return;
+            }
+            var cwd = context.Env.TryGetValue("PWD", out var c) ? c : "/";
+            foreach (var file in args)
+            {
+                var path = _fs.ResolvePath(file, cwd);
+                try
+                {
+                    if (await _fs.Exists(path))
+                    {
+                        var content = await _fs.ReadFile(path);
+                        await _fs.WriteFile(path, content);
+                    }
+                    else
+                    {
+                        await _fs.WriteFile(path, string.Empty);
+                    }
+                }
+                catch (System.Exception ex)
+                {
+                    context.Stderr.WriteLine($"touch: {ex.Message}");
+                }
+            }
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Commands/linux/WcCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/WcCommand.cs
@@ -1,0 +1,40 @@
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class WcCommand : CommandBase
+    {
+        private readonly FileSystemService _fs;
+        public WcCommand(ShellService shell, KernelService kernel, FileSystemService fs) : base("wc", shell, kernel)
+        {
+            _fs = fs;
+        }
+
+        public override string Description => "Word count";
+        public override string Usage => "wc FILE";
+
+        protected override async Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            if (args.Length == 0)
+            {
+                context.Stderr.WriteLine($"Usage: {Usage}");
+                return;
+            }
+            var cwd = context.Env.TryGetValue("PWD", out var c) ? c : "/";
+            var path = _fs.ResolvePath(args[0], cwd);
+            try
+            {
+                var content = await _fs.ReadFile(path);
+                int lines = content.Split('\n').Length;
+                int words = content.Split((char[])null!, System.StringSplitOptions.RemoveEmptyEntries).Length;
+                int bytes = System.Text.Encoding.UTF8.GetByteCount(content);
+                context.Stdout.WriteLine($"{lines} {words} {bytes} {args[0]}");
+            }
+            catch (System.Exception ex)
+            {
+                context.Stderr.WriteLine($"wc: {ex.Message}");
+            }
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Core/AliasService.cs
+++ b/wasm/HackerSimulator.Wasm/Core/AliasService.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace HackerSimulator.Wasm.Core
+{
+    /// <summary>
+    /// Simple service to manage filesystem path aliases.
+    /// This is a lightweight approximation of the JavaScript implementation.
+    /// </summary>
+    public class AliasService
+    {
+        private readonly Dictionary<string, string> _aliases = new();
+
+        public void Register(string alias, string target) => _aliases[alias] = target;
+        public bool Unregister(string alias) => _aliases.Remove(alias);
+        public IEnumerable<(string Alias, string Target)> GetAll() => _aliases.Select(k => (k.Key, k.Value));
+
+        public string Resolve(string path, string? cwd = null)
+        {
+            if (string.IsNullOrEmpty(path))
+                path = string.Empty;
+
+            if (path == "~" || path.StartsWith("~/"))
+            {
+                if (_aliases.TryGetValue("~", out var home))
+                {
+                    path = home + path.Substring(1);
+                }
+            }
+            else
+            {
+                foreach (var kv in _aliases)
+                {
+                    if (kv.Key == "~")
+                        continue;
+                    if (path == kv.Key || path.StartsWith(kv.Key + "/"))
+                    {
+                        path = kv.Value + path.Substring(kv.Key.Length);
+                        break;
+                    }
+                }
+            }
+
+            if (!path.StartsWith("/") && !string.IsNullOrEmpty(cwd))
+            {
+                path = cwd.TrimEnd('/') + "/" + path;
+            }
+
+            return Normalize(path);
+        }
+
+        private static string Normalize(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+                return "/";
+            var parts = new List<string>();
+            foreach (var part in path.Split('/', StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (part == ".")
+                    continue;
+                if (part == "..")
+                {
+                    if (parts.Count > 0)
+                        parts.RemoveAt(parts.Count - 1);
+                    continue;
+                }
+                parts.Add(part);
+            }
+            return "/" + string.Join('/', parts);
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Core/FileSystemService.cs
+++ b/wasm/HackerSimulator.Wasm/Core/FileSystemService.cs
@@ -15,11 +15,13 @@ namespace HackerSimulator.Wasm.Core
     {
         private const string StorageKey = "hacker-os-fs";
         private readonly IJSRuntime _js;
+        private readonly AliasService _aliases;
         private Dictionary<string, EntryRecord> _entries = new();
 
-        public FileSystemService(IJSRuntime js)
+        public FileSystemService(IJSRuntime js, AliasService aliases)
         {
             _js = js;
+            _aliases = aliases;
         }
 
         #region Entry definitions
@@ -86,6 +88,11 @@ namespace HackerSimulator.Wasm.Core
         {
             var json = JsonSerializer.Serialize(_entries);
             await _js.InvokeVoidAsync("localStorage.setItem", StorageKey, json);
+        }
+
+        public string ResolvePath(string path, string? cwd = null)
+        {
+            return _aliases.Resolve(path, cwd);
         }
 
         private static string Normalize(string path)

--- a/wasm/HackerSimulator.Wasm/Program.cs
+++ b/wasm/HackerSimulator.Wasm/Program.cs
@@ -14,6 +14,7 @@ namespace HackerSimulator.Wasm
             builder.RootComponents.Add<App>("#app");
 
             builder.Services.AddSingleton<KernelService>();
+            builder.Services.AddSingleton<AliasService>();
             builder.Services.AddSingleton<ShellService>();
             builder.Services.AddSingleton<FileSystemService>();
 


### PR DESCRIPTION
## Summary
- introduce `AliasService` and integrate with filesystem
- implement simplified versions of linux commands in WASM
- expose command information through `ShellService`
- register `AliasService` in program setup

## Testing
- `dotnet build wasm/HackerSimulator.Wasm/HackerSimulator.Wasm.csproj -v minimal`