### PR TITLE
Add placeholder websites for wasm project

### DIFF
--- a/wasm/HackerSimulator.Wasm/HackerSimulator.Wasm.csproj
+++ b/wasm/HackerSimulator.Wasm/HackerSimulator.Wasm.csproj
@@ -11,5 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Update="Views/**/*.cshtml" CopyToOutputDirectory="Always" />
+    <Content Include="../Web/**/Views/**/*.cshtml" CopyToOutputDirectory="Always" />
+    <Compile Include="../Web/**/Controllers/*.cs" />
   </ItemGroup>
 </Project>

--- a/wasm/Web/cryptobank.com/Controllers/CryptoBankController.cs
+++ b/wasm/Web/cryptobank.com/Controllers/CryptoBankController.cs
@@ -1,0 +1,18 @@
+using HackerSimulator.Wasm.Core;
+using HackerSimulator.Wasm.Web;
+
+namespace HackerSimulator.Wasm.Web.Sites.CryptoBank
+{
+    [Host("cryptobank.com")]
+    public class CryptoBankController : BaseController
+    {
+        public CryptoBankController(NetworkService network, DnsService dns) : base(network, dns) { }
+
+        [Get("/")]
+        public WebResponse Index(WebRequest request)
+        {
+            var model = new { Title = "CryptoBank" };
+            return View("CryptoBank/Index", model);
+        }
+    }
+}

--- a/wasm/Web/cryptobank.com/Views/CryptoBank/Index.cshtml
+++ b/wasm/Web/cryptobank.com/Views/CryptoBank/Index.cshtml
@@ -1,0 +1,6 @@
+<html>
+<body>
+    <h1>@Model.Title</h1>
+    <p>CryptoBank placeholder site.</p>
+</body>
+</html>

--- a/wasm/Web/darknet.market/Controllers/DarknetController.cs
+++ b/wasm/Web/darknet.market/Controllers/DarknetController.cs
@@ -1,0 +1,18 @@
+using HackerSimulator.Wasm.Core;
+using HackerSimulator.Wasm.Web;
+
+namespace HackerSimulator.Wasm.Web.Sites.Darknet
+{
+    [Host("darknet.market")]
+    public class DarknetController : BaseController
+    {
+        public DarknetController(NetworkService network, DnsService dns) : base(network, dns) { }
+
+        [Get("/")]
+        public WebResponse Index(WebRequest request)
+        {
+            var model = new { Title = "DarkNet Market" };
+            return View("Darknet/Index", model);
+        }
+    }
+}

--- a/wasm/Web/darknet.market/Views/Darknet/Index.cshtml
+++ b/wasm/Web/darknet.market/Views/Darknet/Index.cshtml
@@ -1,0 +1,6 @@
+<html>
+<body>
+    <h1>@Model.Title</h1>
+    <p>DarkNet Market placeholder site.</p>
+</body>
+</html>

--- a/wasm/Web/example.com/Controllers/ExampleController.cs
+++ b/wasm/Web/example.com/Controllers/ExampleController.cs
@@ -1,0 +1,18 @@
+using HackerSimulator.Wasm.Core;
+using HackerSimulator.Wasm.Web;
+
+namespace HackerSimulator.Wasm.Web.Sites.Example
+{
+    [Host("example.com")]
+    public class ExampleController : BaseController
+    {
+        public ExampleController(NetworkService network, DnsService dns) : base(network, dns) { }
+
+        [Get("/")]
+        public WebResponse Index(WebRequest request)
+        {
+            var model = new { Title = "Example Website" };
+            return View("Example/Index", model);
+        }
+    }
+}

--- a/wasm/Web/example.com/Views/Example/Index.cshtml
+++ b/wasm/Web/example.com/Views/Example/Index.cshtml
@@ -1,0 +1,6 @@
+<html>
+<body>
+    <h1>@Model.Title</h1>
+    <p>This is a placeholder page for Example.com</p>
+</body>
+</html>

--- a/wasm/Web/hackersearch.net/Controllers/HackerSearchController.cs
+++ b/wasm/Web/hackersearch.net/Controllers/HackerSearchController.cs
@@ -1,0 +1,18 @@
+using HackerSimulator.Wasm.Core;
+using HackerSimulator.Wasm.Web;
+
+namespace HackerSimulator.Wasm.Web.Sites.HackerSearch
+{
+    [Host("hackersearch.net")]
+    public class HackerSearchController : BaseController
+    {
+        public HackerSearchController(NetworkService network, DnsService dns) : base(network, dns) { }
+
+        [Get("/")]
+        public WebResponse Index(WebRequest request)
+        {
+            var model = new { Title = "HackerSearch" };
+            return View("HackerSearch/Index", model);
+        }
+    }
+}

--- a/wasm/Web/hackersearch.net/Views/HackerSearch/Index.cshtml
+++ b/wasm/Web/hackersearch.net/Views/HackerSearch/Index.cshtml
@@ -1,0 +1,6 @@
+<html>
+<body>
+    <h1>@Model.Title</h1>
+    <p>HackerSearch placeholder site.</p>
+</body>
+</html>

--- a/wasm/Web/hackerz.forum/Controllers/HackerzController.cs
+++ b/wasm/Web/hackerz.forum/Controllers/HackerzController.cs
@@ -1,0 +1,18 @@
+using HackerSimulator.Wasm.Core;
+using HackerSimulator.Wasm.Web;
+
+namespace HackerSimulator.Wasm.Web.Sites.Hackerz
+{
+    [Host("hackerz.forum")]
+    public class HackerzController : BaseController
+    {
+        public HackerzController(NetworkService network, DnsService dns) : base(network, dns) { }
+
+        [Get("/")]
+        public WebResponse Index(WebRequest request)
+        {
+            var model = new { Title = "Hackerz Forum" };
+            return View("Hackerz/Index", model);
+        }
+    }
+}

--- a/wasm/Web/hackerz.forum/Views/Hackerz/Index.cshtml
+++ b/wasm/Web/hackerz.forum/Views/Hackerz/Index.cshtml
@@ -1,0 +1,6 @@
+<html>
+<body>
+    <h1>@Model.Title</h1>
+    <p>Hackerz Forum placeholder site.</p>
+</body>
+</html>

--- a/wasm/Web/hackmail.com/Controllers/HackMailController.cs
+++ b/wasm/Web/hackmail.com/Controllers/HackMailController.cs
@@ -1,0 +1,18 @@
+using HackerSimulator.Wasm.Core;
+using HackerSimulator.Wasm.Web;
+
+namespace HackerSimulator.Wasm.Web.Sites.HackMail
+{
+    [Host("hackmail.com")]
+    public class HackMailController : BaseController
+    {
+        public HackMailController(NetworkService network, DnsService dns) : base(network, dns) { }
+
+        [Get("/")]
+        public WebResponse Index(WebRequest request)
+        {
+            var model = new { Title = "HackMail" };
+            return View("HackMail/Index", model);
+        }
+    }
+}

--- a/wasm/Web/hackmail.com/Views/HackMail/Index.cshtml
+++ b/wasm/Web/hackmail.com/Views/HackMail/Index.cshtml
@@ -1,0 +1,6 @@
+<html>
+<body>
+    <h1>@Model.Title</h1>
+    <p>This is HackMail placeholder.</p>
+</body>
+</html>

--- a/wasm/Web/mybank.net/Controllers/MyBankController.cs
+++ b/wasm/Web/mybank.net/Controllers/MyBankController.cs
@@ -1,0 +1,18 @@
+using HackerSimulator.Wasm.Core;
+using HackerSimulator.Wasm.Web;
+
+namespace HackerSimulator.Wasm.Web.Sites.MyBank
+{
+    [Host("mybank.net")]
+    public class MyBankController : BaseController
+    {
+        public MyBankController(NetworkService network, DnsService dns) : base(network, dns) { }
+
+        [Get("/")]
+        public WebResponse Index(WebRequest request)
+        {
+            var model = new { Title = "MyBank" };
+            return View("MyBank/Index", model);
+        }
+    }
+}

--- a/wasm/Web/mybank.net/Views/MyBank/Index.cshtml
+++ b/wasm/Web/mybank.net/Views/MyBank/Index.cshtml
@@ -1,0 +1,6 @@
+<html>
+<body>
+    <h1>@Model.Title</h1>
+    <p>Welcome to MyBank (placeholder).</p>
+</body>
+</html>

--- a/wasm/Web/targetbank.com/Controllers/TargetBankController.cs
+++ b/wasm/Web/targetbank.com/Controllers/TargetBankController.cs
@@ -1,0 +1,18 @@
+using HackerSimulator.Wasm.Core;
+using HackerSimulator.Wasm.Web;
+
+namespace HackerSimulator.Wasm.Web.Sites.TargetBank
+{
+    [Host("targetbank.com")]
+    public class TargetBankController : BaseController
+    {
+        public TargetBankController(NetworkService network, DnsService dns) : base(network, dns) { }
+
+        [Get("/")]
+        public WebResponse Index(WebRequest request)
+        {
+            var model = new { Title = "TargetBank" };
+            return View("TargetBank/Index", model);
+        }
+    }
+}

--- a/wasm/Web/targetbank.com/Views/TargetBank/Index.cshtml
+++ b/wasm/Web/targetbank.com/Views/TargetBank/Index.cshtml
@@ -1,0 +1,6 @@
+<html>
+<body>
+    <h1>@Model.Title</h1>
+    <p>TargetBank placeholder site.</p>
+</body>
+</html>

--- a/wasm/Web/techcorp.com/Controllers/TechCorpController.cs
+++ b/wasm/Web/techcorp.com/Controllers/TechCorpController.cs
@@ -1,0 +1,18 @@
+using HackerSimulator.Wasm.Core;
+using HackerSimulator.Wasm.Web;
+
+namespace HackerSimulator.Wasm.Web.Sites.TechCorp
+{
+    [Host("techcorp.com")]
+    public class TechCorpController : BaseController
+    {
+        public TechCorpController(NetworkService network, DnsService dns) : base(network, dns) { }
+
+        [Get("/")]
+        public WebResponse Index(WebRequest request)
+        {
+            var model = new { Title = "TechCorp" };
+            return View("TechCorp/Index", model);
+        }
+    }
+}

--- a/wasm/Web/techcorp.com/Views/TechCorp/Index.cshtml
+++ b/wasm/Web/techcorp.com/Views/TechCorp/Index.cshtml
@@ -1,0 +1,6 @@
+<html>
+<body>
+    <h1>@Model.Title</h1>
+    <p>TechCorp placeholder site.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- set up simple controller/view pairs for example.com, mybank.net and other sites
- include new website paths in csproj

## Testing
- `npm test` *(fails: Missing script)*
- `dotnet test wasm/HackerSimulator.Wasm.sln`