### PR TITLE
Implement linux command arguments in wasm

### DIFF
--- a/wasm/HackerSimulator.Wasm/Commands/linux/CatCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/CatCommand.cs
@@ -12,24 +12,54 @@ namespace HackerSimulator.Wasm.Commands.Linux
         }
 
         public override string Description => "Concatenate files";
-        public override string Usage => "cat <file>...";
+        public override string Usage => "cat [-n] [-E] <file>...";
 
         protected override async Task ExecuteInternal(string[] args, CommandContext context)
         {
-            if (args.Length == 0)
+            var files = new System.Collections.Generic.List<string>();
+            bool number = false;
+            bool showEnds = false;
+
+            foreach (var arg in args)
+            {
+                if (arg == "-n")
+                    number = true;
+                else if (arg == "-E")
+                    showEnds = true;
+                else if (arg.StartsWith("-"))
+                {
+                    context.Stderr.WriteLine($"cat: invalid option '{arg}'");
+                    return;
+                }
+                else
+                    files.Add(arg);
+            }
+
+            if (files.Count == 0)
             {
                 context.Stderr.WriteLine("cat: missing file operand");
                 return;
             }
 
             var cwd = context.Env.TryGetValue("PWD", out var c) ? c : "/";
-            foreach (var file in args)
+            int lineNo = 1;
+            foreach (var file in files)
             {
                 var path = _fs.ResolvePath(file, cwd);
                 try
                 {
                     var content = await _fs.ReadFile(path);
-                    context.Stdout.WriteLine(content);
+                    var lines = content.Split('\n');
+                    foreach (var line in lines)
+                    {
+                        var output = string.Empty;
+                        if (number)
+                            output += $"{lineNo++,6}  ";
+                        output += line;
+                        if (showEnds)
+                            output += "$";
+                        context.Stdout.WriteLine(output);
+                    }
                 }
                 catch (System.Exception ex)
                 {

--- a/wasm/HackerSimulator.Wasm/Commands/linux/CpCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/CpCommand.cs
@@ -12,32 +12,76 @@ namespace HackerSimulator.Wasm.Commands.Linux
         }
 
         public override string Description => "Copy files";
-        public override string Usage => "cp SOURCE DEST";
+        public override string Usage => "cp [-r] [-v] SOURCE... DEST";
 
         protected override async Task ExecuteInternal(string[] args, CommandContext context)
         {
-            if (args.Length < 2)
+            bool recursive = false;
+            bool verbose = false;
+            var paths = new System.Collections.Generic.List<string>();
+
+            foreach (var a in args)
+            {
+                if (a == "-r" || a == "-R" || a == "--recursive")
+                    recursive = true;
+                else if (a == "-v" || a == "--verbose")
+                    verbose = true;
+                else if (a.StartsWith("-"))
+                {
+                    context.Stderr.WriteLine($"cp: invalid option {a}");
+                    return;
+                }
+                else
+                    paths.Add(a);
+            }
+
+            if (paths.Count < 2)
             {
                 context.Stderr.WriteLine($"Usage: {Usage}");
                 return;
             }
 
             var cwd = context.Env.TryGetValue("PWD", out var c) ? c : "/";
-            var dest = _fs.ResolvePath(args[^1], cwd);
-            for (int i = 0; i < args.Length - 1; i++)
+            var dest = _fs.ResolvePath(paths[^1], cwd);
+            FileSystemService.FileStats? destStat = null;
+            try { destStat = await _fs.Stat(dest); } catch { }
+
+            for (int i = 0; i < paths.Count - 1; i++)
             {
-                var src = _fs.ResolvePath(args[i], cwd);
-                var target = dest;
-                if (args.Length > 2)
-                    target = dest.TrimEnd('/') + "/" + System.IO.Path.GetFileName(src);
+                var src = _fs.ResolvePath(paths[i], cwd);
+                var target = destStat != null && destStat.IsDirectory ? dest.TrimEnd('/') + "/" + System.IO.Path.GetFileName(src) : dest;
                 try
                 {
-                    await _fs.Copy(src, target);
+                    await CopyEntry(src, target, recursive);
+                    if (verbose)
+                        context.Stdout.WriteLine($"'{paths[i]}' -> '{target}'");
                 }
                 catch (System.Exception ex)
                 {
-                    context.Stderr.WriteLine($"cp: {args[i]}: {ex.Message}");
+                    context.Stderr.WriteLine($"cp: {paths[i]}: {ex.Message}");
                 }
+            }
+        }
+
+        private async Task CopyEntry(string source, string dest, bool recursive)
+        {
+            var stats = await _fs.Stat(source);
+            if (stats.IsDirectory)
+            {
+                if (!recursive)
+                    throw new System.Exception("omitting directory");
+
+                try { await _fs.CreateDirectory(dest); } catch { }
+                var entries = await _fs.ReadDirectory(source);
+                foreach (var e in entries)
+                {
+                    await CopyEntry(source.TrimEnd('/') + "/" + e.Name, dest.TrimEnd('/') + "/" + e.Name, true);
+                }
+            }
+            else
+            {
+                var content = await _fs.ReadFile(source);
+                await _fs.WriteFile(dest, content);
             }
         }
     }

--- a/wasm/HackerSimulator.Wasm/Commands/linux/GrepCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/GrepCommand.cs
@@ -12,34 +12,128 @@ namespace HackerSimulator.Wasm.Commands.Linux
         }
 
         public override string Description => "Search text";
-        public override string Usage => "grep PATTERN FILE";
+        public override string Usage => "grep [options] PATTERN [FILE...]";
 
         protected override async Task ExecuteInternal(string[] args, CommandContext context)
         {
-            if (args.Length < 2)
+            bool ignoreCase = false;
+            bool invert = false;
+            bool showLine = false;
+            bool countOnly = false;
+            bool onlyMatch = false;
+            bool recursive = false;
+
+            string? pattern = null;
+            var files = new System.Collections.Generic.List<string>();
+
+            foreach (var a in args)
+            {
+                switch (a)
+                {
+                    case "-i":
+                    case "--ignore-case":
+                        ignoreCase = true; break;
+                    case "-v":
+                    case "--invert-match":
+                        invert = true; break;
+                    case "-n":
+                    case "--line-number":
+                        showLine = true; break;
+                    case "-c":
+                    case "--count":
+                        countOnly = true; break;
+                    case "-o":
+                    case "--only-matching":
+                        onlyMatch = true; break;
+                    case "-r":
+                    case "-R":
+                    case "--recursive":
+                        recursive = true; break;
+                    default:
+                        if (pattern == null)
+                            pattern = a;
+                        else
+                            files.Add(a);
+                        break;
+                }
+            }
+
+            if (string.IsNullOrEmpty(pattern))
             {
                 context.Stderr.WriteLine($"Usage: {Usage}");
                 return;
             }
-            var pattern = args[0];
+
             var cwd = context.Env.TryGetValue("PWD", out var c) ? c : "/";
-            for (int i = 1; i < args.Length; i++)
+            if (files.Count == 0)
             {
-                var file = _fs.ResolvePath(args[i], cwd);
-                try
+                context.Stderr.WriteLine("grep: no files specified");
+                return;
+            }
+
+            var options = ignoreCase ? System.Text.RegularExpressions.RegexOptions.IgnoreCase : System.Text.RegularExpressions.RegexOptions.None;
+            var regex = new System.Text.RegularExpressions.Regex(pattern, options);
+
+            foreach (var f in files)
+            {
+                var path = _fs.ResolvePath(f, cwd);
+                await ProcessPath(path, f, regex, context, invert, showLine, countOnly, onlyMatch, recursive, files.Count > 1);
+            }
+        }
+
+        private async Task ProcessPath(string path, string display, System.Text.RegularExpressions.Regex regex, CommandContext context, bool invert, bool showLine, bool countOnly, bool onlyMatch, bool recursive, bool prefix)
+        {
+            FileSystemService.FileStats stats;
+            try { stats = await _fs.Stat(path); } catch (System.Exception ex) { context.Stderr.WriteLine($"grep: {display}: {ex.Message}"); return; }
+            if (stats.IsDirectory)
+            {
+                if (!recursive)
                 {
-                    var text = await _fs.ReadFile(file);
-                    var lines = text.Split('\n');
-                    for (int ln = 0; ln < lines.Length; ln++)
+                    context.Stderr.WriteLine($"grep: {display}: Is a directory");
+                    return;
+                }
+                var entries = await _fs.ReadDirectory(path);
+                foreach (var e in entries)
+                    await ProcessPath(path.TrimEnd('/') + "/" + e.Name, display + "/" + e.Name, regex, context, invert, showLine, countOnly, onlyMatch, true, prefix);
+                return;
+            }
+
+            string text;
+            try { text = await _fs.ReadFile(path); } catch (System.Exception ex) { context.Stderr.WriteLine($"grep: {display}: {ex.Message}"); return; }
+            var lines = text.Split('\n');
+            int matchCount = 0;
+            for (int ln = 0; ln < lines.Length; ln++)
+            {
+                bool match = regex.IsMatch(lines[ln]);
+                if (invert) match = !match;
+                if (!match) continue;
+                matchCount++;
+                if (countOnly) continue;
+                if (onlyMatch)
+                {
+                    var matches = regex.Matches(lines[ln]);
+                    foreach (System.Text.RegularExpressions.Match m in matches)
                     {
-                        if (lines[ln].Contains(pattern))
-                            context.Stdout.WriteLine($"{ln + 1}:{lines[ln]}");
+                        var outLine = string.Empty;
+                        if (prefix) outLine += display + ":";
+                        if (showLine) outLine += (ln + 1) + ":";
+                        outLine += m.Value;
+                        context.Stdout.WriteLine(outLine);
                     }
                 }
-                catch (System.Exception ex)
+                else
                 {
-                    context.Stderr.WriteLine($"grep: {args[i]}: {ex.Message}");
+                    var outLine = string.Empty;
+                    if (prefix) outLine += display + ":";
+                    if (showLine) outLine += (ln + 1) + ":";
+                    outLine += lines[ln];
+                    context.Stdout.WriteLine(outLine);
                 }
+            }
+            if (countOnly)
+            {
+                var prefixStr = prefix ? display + ":" : string.Empty;
+                context.Stdout.WriteLine(prefixStr + matchCount.ToString());
             }
         }
     }

--- a/wasm/HackerSimulator.Wasm/Commands/linux/HeadCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/HeadCommand.cs
@@ -12,27 +12,57 @@ namespace HackerSimulator.Wasm.Commands.Linux
         }
 
         public override string Description => "Output start of files";
-        public override string Usage => "head FILE";
+        public override string Usage => "head [-n N] FILE";
 
         protected override async Task ExecuteInternal(string[] args, CommandContext context)
         {
-            if (args.Length == 0)
+            int num = 10;
+            var files = new System.Collections.Generic.List<string>();
+
+            for (int i = 0; i < args.Length; i++)
+            {
+                var a = args[i];
+                if (a == "-n" && i + 1 < args.Length)
+                {
+                    if (int.TryParse(args[i + 1], out var n)) num = n;
+                    i++;
+                }
+                else if (a.StartsWith("-") && int.TryParse(a.Substring(1), out var n))
+                {
+                    num = n;
+                }
+                else if (a.StartsWith("-"))
+                {
+                    context.Stderr.WriteLine($"head: invalid option {a}");
+                    return;
+                }
+                else
+                {
+                    files.Add(a);
+                }
+            }
+
+            if (files.Count == 0)
             {
                 context.Stderr.WriteLine($"Usage: {Usage}");
                 return;
             }
+
             var cwd = context.Env.TryGetValue("PWD", out var c) ? c : "/";
-            var path = _fs.ResolvePath(args[0], cwd);
-            try
+            foreach (var f in files)
             {
-                var content = await _fs.ReadFile(path);
-                var lines = content.Split('\n');
-                for (int i = 0; i < System.Math.Min(10, lines.Length); i++)
-                    context.Stdout.WriteLine(lines[i]);
-            }
-            catch (System.Exception ex)
-            {
-                context.Stderr.WriteLine($"head: {ex.Message}");
+                var path = _fs.ResolvePath(f, cwd);
+                try
+                {
+                    var content = await _fs.ReadFile(path);
+                    var lines = content.Split('\n');
+                    for (int l = 0; l < System.Math.Min(num, lines.Length); l++)
+                        context.Stdout.WriteLine(lines[l]);
+                }
+                catch (System.Exception ex)
+                {
+                    context.Stderr.WriteLine($"head: {ex.Message}");
+                }
             }
         }
     }

--- a/wasm/HackerSimulator.Wasm/Commands/linux/LsCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/LsCommand.cs
@@ -12,24 +12,69 @@ namespace HackerSimulator.Wasm.Commands.Linux
         }
 
         public override string Description => "List directory contents";
-        public override string Usage => "ls [path]";
+        public override string Usage => "ls [-a] [-l] [-h] [path]";
 
         protected override async Task ExecuteInternal(string[] args, CommandContext context)
         {
+            bool showAll = false;
+            bool longFormat = false;
+            bool human = false;
+            string? target = null;
+
+            foreach (var a in args)
+            {
+                if (a == "-a" || a == "--all") showAll = true;
+                else if (a == "-l") longFormat = true;
+                else if (a == "-h") human = true;
+                else if (a.StartsWith("-"))
+                {
+                    context.Stderr.WriteLine($"ls: invalid option {a}");
+                    return;
+                }
+                else target = a;
+            }
+
             var cwd = context.Env.TryGetValue("PWD", out var c) ? c : "/";
-            var path = args.Length > 0 ? _fs.ResolvePath(args[0], cwd) : cwd;
+            var path = target != null ? _fs.ResolvePath(target, cwd) : cwd;
             try
             {
                 var entries = await _fs.ReadDirectory(path);
                 foreach (var e in entries)
                 {
-                    context.Stdout.WriteLine(e.Name + (e.IsDirectory ? "/" : string.Empty));
+                    if (!showAll && e.Name.StartsWith("."))
+                        continue;
+                    if (longFormat)
+                    {
+                        var perms = e.Metadata?.Permissions ?? (e.IsDirectory ? "drwxr-xr-x" : "-rw-r--r--");
+                        var owner = e.Metadata?.Owner ?? "user";
+                        var sizeVal = e.Metadata?.Size ?? 0;
+                        var size = human ? FormatSize(sizeVal) : sizeVal.ToString();
+                        var date = e.Metadata != null ? System.DateTimeOffset.FromUnixTimeMilliseconds(e.Metadata.Modified).ToLocalTime().ToString("MMM dd HH:mm") : string.Empty;
+                        context.Stdout.WriteLine($"{perms} 1 {owner} {owner} {size,8} {date} {e.Name}{(e.IsDirectory ? "/" : string.Empty)}");
+                    }
+                    else
+                    {
+                        context.Stdout.WriteLine(e.Name + (e.IsDirectory ? "/" : string.Empty));
+                    }
                 }
             }
             catch (System.Exception ex)
             {
                 context.Stderr.WriteLine($"ls: {ex.Message}");
             }
+        }
+
+        private string FormatSize(long bytes)
+        {
+            double size = bytes;
+            string[] units = new[] { "B", "K", "M", "G", "T" };
+            int index = 0;
+            while (size >= 1024 && index < units.Length - 1)
+            {
+                size /= 1024;
+                index++;
+            }
+            return string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:0.#}{1}", size, units[index]);
         }
     }
 }

--- a/wasm/HackerSimulator.Wasm/Commands/linux/RmCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/RmCommand.cs
@@ -12,28 +12,70 @@ namespace HackerSimulator.Wasm.Commands.Linux
         }
 
         public override string Description => "Remove files";
-        public override string Usage => "rm FILE";
+        public override string Usage => "rm [-r] [-f] [-v] FILE...";
 
         protected override async Task ExecuteInternal(string[] args, CommandContext context)
         {
-            if (args.Length == 0)
+            bool recursive = false;
+            bool force = false;
+            bool verbose = false;
+            var files = new System.Collections.Generic.List<string>();
+
+            foreach (var a in args)
+            {
+                if (a == "-r" || a == "-R" || a == "--recursive")
+                    recursive = true;
+                else if (a == "-f" || a == "--force")
+                    force = true;
+                else if (a == "-v" || a == "--verbose")
+                    verbose = true;
+                else if (a.StartsWith("-"))
+                {
+                    context.Stderr.WriteLine($"rm: invalid option {a}");
+                    return;
+                }
+                else
+                    files.Add(a);
+            }
+
+            if (files.Count == 0)
             {
                 context.Stderr.WriteLine($"Usage: {Usage}");
                 return;
             }
+
             var cwd = context.Env.TryGetValue("PWD", out var c) ? c : "/";
-            foreach (var arg in args)
+            foreach (var f in files)
             {
-                var path = _fs.ResolvePath(arg, cwd);
+                var path = _fs.ResolvePath(f, cwd);
                 try
                 {
-                    await _fs.DeleteEntry(path);
+                    await RemoveEntry(path, recursive);
+                    if (verbose)
+                        context.Stdout.WriteLine($"removed '{f}'");
                 }
                 catch (System.Exception ex)
                 {
-                    context.Stderr.WriteLine($"rm: {ex.Message}");
+                    if (!force)
+                        context.Stderr.WriteLine($"rm: {ex.Message}");
                 }
             }
+        }
+
+        private async Task RemoveEntry(string path, bool recursive)
+        {
+            var stat = await _fs.Stat(path);
+            if (stat.IsDirectory)
+            {
+                if (!recursive)
+                    throw new System.Exception("is a directory");
+                var entries = await _fs.ReadDirectory(path);
+                foreach (var e in entries)
+                {
+                    await RemoveEntry(path.TrimEnd('/') + "/" + e.Name, true);
+                }
+            }
+            await _fs.DeleteEntry(path);
         }
     }
 }

--- a/wasm/HackerSimulator.Wasm/Commands/linux/TailCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/TailCommand.cs
@@ -12,28 +12,58 @@ namespace HackerSimulator.Wasm.Commands.Linux
         }
 
         public override string Description => "Output end of files";
-        public override string Usage => "tail FILE";
+        public override string Usage => "tail [-n N] FILE";
 
         protected override async Task ExecuteInternal(string[] args, CommandContext context)
         {
-            if (args.Length == 0)
+            int num = 10;
+            var files = new System.Collections.Generic.List<string>();
+
+            for (int i = 0; i < args.Length; i++)
+            {
+                var a = args[i];
+                if (a == "-n" && i + 1 < args.Length)
+                {
+                    if (int.TryParse(args[i + 1], out var n)) num = n;
+                    i++;
+                }
+                else if (a.StartsWith("-") && int.TryParse(a.Substring(1), out var n))
+                {
+                    num = n;
+                }
+                else if (a.StartsWith("-"))
+                {
+                    context.Stderr.WriteLine($"tail: invalid option {a}");
+                    return;
+                }
+                else
+                {
+                    files.Add(a);
+                }
+            }
+
+            if (files.Count == 0)
             {
                 context.Stderr.WriteLine($"Usage: {Usage}");
                 return;
             }
+
             var cwd = context.Env.TryGetValue("PWD", out var c) ? c : "/";
-            var path = _fs.ResolvePath(args[0], cwd);
-            try
+            foreach (var f in files)
             {
-                var content = await _fs.ReadFile(path);
-                var lines = content.Split('\n');
-                int start = System.Math.Max(lines.Length - 10, 0);
-                for (int i = start; i < lines.Length; i++)
-                    context.Stdout.WriteLine(lines[i]);
-            }
-            catch (System.Exception ex)
-            {
-                context.Stderr.WriteLine($"tail: {ex.Message}");
+                var path = _fs.ResolvePath(f, cwd);
+                try
+                {
+                    var content = await _fs.ReadFile(path);
+                    var lines = content.Split('\n');
+                    int start = System.Math.Max(lines.Length - num, 0);
+                    for (int l = start; l < lines.Length; l++)
+                        context.Stdout.WriteLine(lines[l]);
+                }
+                catch (System.Exception ex)
+                {
+                    context.Stderr.WriteLine($"tail: {ex.Message}");
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- port CLI options from JS version into C# wasm commands
- document new options in `Usage` text

## Testing
- `dotnet build wasm/HackerSimulator.Wasm/HackerSimulator.Wasm.csproj -clp:ErrorsOnly`