### PR TITLE
Add Blazor File Explorer

### DIFF
--- a/wasm/HackerSimulator.Wasm/App/FileExplorerApp.razor
+++ b/wasm/HackerSimulator.Wasm/App/FileExplorerApp.razor
@@ -2,16 +2,77 @@
 @inherits HackerSimulator.Wasm.Windows.WindowBase
 @inject HackerSimulator.Wasm.Core.ShellService Shell
 
-<div class="file-explorer">
-    <div class="toolbar">
-        <button @onclick="Up">Up</button>
-        <input type="text" @bind="_path" class="path-box" />
-        <button @onclick="Load">Go</button>
+<div class="file-explorer-app" @onclick="HideMenu">
+    <div class="file-explorer-toolbar">
+        <div class="navigation-buttons">
+            <button class="navigation-btn" @onclick="Back" disabled="@IsBackDisabled">Back</button>
+            <button class="navigation-btn" @onclick="Forward" disabled="@IsForwardDisabled">Forward</button>
+            <button class="navigation-btn" @onclick="Up">Up</button>
+            <button class="navigation-btn" @onclick="Refresh">Refresh</button>
+        </div>
+        <div class="path-bar">
+            <input class="path-input" @bind="_path" @bind:event="oninput" @onkeydown="OnPathKeyDown" />
+        </div>
+        <div class="view-options">
+            <button class="view-btn @(ViewMode == ViewModes.Grid ? "active" : null)" @onclick="() => SetView(ViewModes.Grid)">Grid</button>
+            <button class="view-btn @(ViewMode == ViewModes.List ? "active" : null)" @onclick="() => SetView(ViewModes.List)">List</button>
+            <button class="view-btn show-hidden @(ShowHidden ? "active" : null)" @onclick="ToggleHidden">Hidden</button>
+        </div>
     </div>
-    <ul class="entries">
-        @foreach (var entry in _entries)
-        {
-            <li @ondblclick="() => Open(entry)">@entry.Name@(entry.IsDirectory ? "/" : "")</li>
-        }
-    </ul>
+    <div class="file-explorer-main">
+        <div class="file-explorer-sidebar">
+            <div class="sidebar-section">
+                <div class="sidebar-header">Favorites</div>
+                <div class="sidebar-item" @onclick='() => Navigate("/home/user")'>🏠 Home</div>
+                <div class="sidebar-item" @onclick='() => Navigate("/home/user/Desktop")'>🖥️ Desktop</div>
+                <div class="sidebar-item" @onclick='() => Navigate("/home/user/Documents")'>📄 Documents</div>
+                <div class="sidebar-item" @onclick='() => Navigate("/home/user/Downloads")'>⬇️ Downloads</div>
+            </div>
+            <div class="sidebar-section">
+                <div class="sidebar-header">Devices</div>
+                <div class="sidebar-item" @onclick='() => Navigate("/")'>💻 System</div>
+                <div class="sidebar-item" @onclick='() => Navigate("/mnt")'>💿 Media</div>
+            </div>
+        </div>
+        <div class="file-explorer-content" @oncontextmenu="ShowBackgroundMenu">
+            <div class="file-list @(ViewMode == ViewModes.Grid ? "grid" : "list")">
+                @if (_entries.Count == 0)
+                {
+                    <div class="empty-folder">This folder is empty</div>
+                }
+                else
+                {
+                    @foreach (var entry in _entries)
+                    {
+                        var path = EntryPath(entry);
+                        <div class="file-item @(Selected.Contains(path) ? "selected" : null)" @onclick="() => Select(entry)" @ondblclick="() => Open(entry)" @oncontextmenu="e => ShowContextMenu(e, entry)">
+                            <span class="file-icon">@(entry.IsDirectory ? "📁" : "📄")</span>
+                            <span class="file-name">@entry.Name</span>
+                        </div>
+                    }
+                }
+            </div>
+        </div>
+    </div>
+
+    @if (_showMenu)
+    {
+        <div class="context-menu" style="left:@(_menuX)px; top:@(_menuY)px; display:block;" @onclick:stopPropagation="true">
+            @if (_menuEntry != null)
+            {
+                <div class="context-menu-item" @onclick='() => ContextAction("open")'>Open</div>
+                <div class="context-menu-item" @onclick='() => ContextAction("rename")'>Rename</div>
+                <div class="context-menu-item" @onclick='() => ContextAction("delete")'>Delete</div>
+                <div class="context-menu-separator"></div>
+                <div class="context-menu-item" @onclick='() => ContextAction("copy")'>Copy</div>
+                <div class="context-menu-item" @onclick='() => ContextAction("cut")'>Cut</div>
+            }
+            else
+            {
+                <div class="context-menu-item" @onclick='() => ContextAction("new-file")'>New File</div>
+                <div class="context-menu-item" @onclick='() => ContextAction("new-folder")'>New Folder</div>
+            }
+            <div class="context-menu-item" @onclick='() => ContextAction("paste")'>Paste</div>
+        </div>
+    }
 </div>

--- a/wasm/HackerSimulator.Wasm/App/FileExplorerApp.razor.cs
+++ b/wasm/HackerSimulator.Wasm/App/FileExplorerApp.razor.cs
@@ -1,6 +1,10 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
 using HackerSimulator.Wasm.Core;
 
 namespace HackerSimulator.Wasm.Apps
@@ -8,42 +12,223 @@ namespace HackerSimulator.Wasm.Apps
     public partial class FileExplorerApp : Windows.WindowBase
     {
         [Inject] private FileSystemService FS { get; set; } = default!;
+        [Inject] private IJSRuntime JS { get; set; } = default!;
 
-        private string _path = "/";
+        private string _path = "/home/user";
         private List<FileSystemService.FileSystemEntry> _entries = new();
+        private HashSet<string> Selected { get; } = new();
+        private List<string> _history = new();
+        private int _historyIndex = -1;
+        private (bool cut, List<string> paths)? _clipboard;
+
+        private bool ShowHidden { get; set; }
+        private ViewModes ViewMode { get; set; } = ViewModes.List;
+
+        private bool IsBackDisabled => _historyIndex <= 0;
+        private bool IsForwardDisabled => _historyIndex >= _history.Count - 1;
 
         protected override void OnInitialized()
         {
             base.OnInitialized();
             Title = "File Explorer";
-            
+            _history.Add(_path);
+            _historyIndex = 0;
             _ = Load();
         }
 
         private async Task Load()
         {
-            _entries = new List<FileSystemService.FileSystemEntry>(await FS.ReadDirectory(_path));
+            var entries = await FS.ReadDirectory(_path);
+            _entries = entries
+                .Where(e => ShowHidden || !e.Name.StartsWith('.'))
+                .OrderBy(e => e.Type)
+                .ThenBy(e => e.Name)
+                .ToList();
+            Selected.Clear();
+            StateHasChanged();
         }
 
-        private async Task Up()
+        private async Task Navigate(string path)
         {
-            if (_path == "/") return;
-            var idx = _path.LastIndexOf('/');
-            _path = idx <= 0 ? "/" : _path[..idx];
+            _path = FS.ResolvePath(path, _path);
+            if (_historyIndex < _history.Count - 1)
+                _history.RemoveRange(_historyIndex + 1, _history.Count - _historyIndex - 1);
+            if (_history.Count == 0 || _history[^1] != _path)
+            {
+                _history.Add(_path);
+                _historyIndex = _history.Count - 1;
+            }
             await Load();
+        }
+
+        private Task Up()
+        {
+            if (_path == "/") return Task.CompletedTask;
+            var idx = _path.LastIndexOf('/');
+            var parent = idx <= 0 ? "/" : _path[..idx];
+            return Navigate(parent);
+        }
+
+        private Task Back()
+        {
+            if (IsBackDisabled) return Task.CompletedTask;
+            _historyIndex--;
+            return Navigate(_history[_historyIndex]);
+        }
+
+        private Task Forward()
+        {
+            if (IsForwardDisabled) return Task.CompletedTask;
+            _historyIndex++;
+            return Navigate(_history[_historyIndex]);
+        }
+
+        private Task Refresh() => Load();
+
+        private string EntryPath(FileSystemService.FileSystemEntry e)
+            => (_path == "/" ? string.Empty : _path) + "/" + e.Name;
+
+        private void Select(FileSystemService.FileSystemEntry entry)
+        {
+            var path = EntryPath(entry);
+            if (Selected.Contains(path))
+                Selected.Remove(path);
+            else
+            {
+                Selected.Clear();
+                Selected.Add(path);
+            }
         }
 
         private async Task Open(FileSystemService.FileSystemEntry entry)
         {
             if (entry.IsDirectory)
-            {
-                _path = (_path == "/" ? string.Empty : _path) + "/" + entry.Name;
-                await Load();
-            }
+                await Navigate(EntryPath(entry));
             else
-            {
-                await Shell.Run("texteditorapp", new[] { (_path == "/" ? string.Empty : _path) + "/" + entry.Name });
-            }
+                await Shell.Run("texteditorapp", new[] { EntryPath(entry) });
         }
+
+        private async Task NewFile()
+        {
+            var name = await JS.InvokeAsync<string?>("prompt", "File name?");
+            if (string.IsNullOrWhiteSpace(name)) return;
+            await FS.WriteFile((_path == "/" ? string.Empty : _path) + "/" + name, string.Empty);
+            await Load();
+        }
+
+        private async Task NewFolder()
+        {
+            var name = await JS.InvokeAsync<string?>("prompt", "Folder name?");
+            if (string.IsNullOrWhiteSpace(name)) return;
+            await FS.CreateDirectory((_path == "/" ? string.Empty : _path) + "/" + name);
+            await Load();
+        }
+
+        private async Task DeleteSelection()
+        {
+            if (Selected.Count == 0) return;
+            var ok = await JS.InvokeAsync<bool>("confirm", "Delete selected?");
+            if (!ok) return;
+            foreach (var p in Selected)
+                await FS.Remove(p);
+            await Load();
+        }
+
+        private async Task Rename(FileSystemService.FileSystemEntry entry)
+        {
+            var oldPath = EntryPath(entry);
+            var newName = await JS.InvokeAsync<string?>("prompt", "New name", entry.Name);
+            if (string.IsNullOrWhiteSpace(newName) || newName == entry.Name) return;
+            var newPath = (_path == "/" ? string.Empty : _path) + "/" + newName;
+            await FS.Move(oldPath, newPath);
+            await Load();
+        }
+
+        private void Copy() { if (Selected.Count > 0) _clipboard = (false, Selected.ToList()); }
+        private void Cut() { if (Selected.Count > 0) _clipboard = (true, Selected.ToList()); }
+
+        private async Task Paste()
+        {
+            if (_clipboard == null) return;
+            foreach (var p in _clipboard.Value.paths)
+            {
+                var name = p.Split('/').Last();
+                var dest = (_path == "/" ? string.Empty : _path) + "/" + name;
+                if (_clipboard.Value.cut)
+                    await FS.Move(p, dest);
+                else
+                    await FS.Copy(p, dest);
+            }
+            if (_clipboard.Value.cut) _clipboard = null;
+            await Load();
+        }
+
+        private async Task ToggleHidden()
+        {
+            ShowHidden = !ShowHidden;
+            await Load();
+        }
+
+        private Task SetView(ViewModes mode)
+        {
+            ViewMode = mode;
+            return Task.CompletedTask;
+        }
+
+        private async Task OnPathKeyDown(KeyboardEventArgs e)
+        {
+            if (e.Key == "Enter")
+                await Navigate(_path);
+        }
+
+        private bool _showMenu;
+        private double _menuX;
+        private double _menuY;
+        private FileSystemService.FileSystemEntry? _menuEntry;
+
+        private void ShowContextMenu(MouseEventArgs e, FileSystemService.FileSystemEntry? entry)
+        {
+            _menuEntry = entry;
+            _menuX = e.ClientX;
+            _menuY = e.ClientY;
+            _showMenu = true;
+        }
+
+        private void ShowBackgroundMenu(MouseEventArgs e) => ShowContextMenu(e, null);
+        private void HideMenu() => _showMenu = false;
+
+        private async Task ContextAction(string action)
+        {
+            switch (action)
+            {
+                case "open" when _menuEntry != null:
+                    await Open(_menuEntry);
+                    break;
+                case "rename" when _menuEntry != null:
+                    await Rename(_menuEntry);
+                    break;
+                case "delete":
+                    await DeleteSelection();
+                    break;
+                case "new-file":
+                    await NewFile();
+                    break;
+                case "new-folder":
+                    await NewFolder();
+                    break;
+                case "copy":
+                    Copy();
+                    break;
+                case "cut":
+                    Cut();
+                    break;
+                case "paste":
+                    await Paste();
+                    break;
+            }
+            _showMenu = false;
+        }
+
+        private enum ViewModes { List, Grid }
     }
 }

--- a/wasm/HackerSimulator.Wasm/App/FileExplorerApp.razor.css
+++ b/wasm/HackerSimulator.Wasm/App/FileExplorerApp.razor.css
@@ -1,0 +1,81 @@
+.file-explorer-app {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    width: 100%;
+    background: #1e1e1e;
+    color: #d4d4d4;
+    font-family: sans-serif;
+}
+.file-explorer-toolbar {
+    display: flex;
+    padding: 4px;
+    background: #252526;
+    border-bottom: 1px solid #3c3c3c;
+}
+.navigation-buttons button,
+.view-options button {
+    background: none;
+    border: none;
+    color: inherit;
+    padding: 4px 8px;
+    margin-right: 2px;
+    cursor: pointer;
+    border-radius: 3px;
+}
+.navigation-buttons button:hover,
+.view-options button:hover {
+    background: #2a2d2e;
+}
+.view-options .active {
+    background: #094771;
+}
+.path-bar {
+    flex: 1;
+    padding: 0 4px;
+}
+.path-input {
+    width: 100%;
+    background: #3c3c3c;
+    border: 1px solid #555;
+    color: inherit;
+    padding: 4px 6px;
+    border-radius: 3px;
+}
+.file-explorer-main {
+    display: flex;
+    flex: 1;
+    overflow: hidden;
+}
+.file-explorer-sidebar {
+    width: 180px;
+    background: #252526;
+    border-right: 1px solid #333;
+    padding: 4px;
+    overflow-y: auto;
+}
+.sidebar-item {
+    padding: 4px 8px;
+    cursor: pointer;
+    border-radius: 3px;
+}
+.sidebar-item:hover { background:#2a2d2e; }
+.sidebar-item.active { background:#37373d; }
+.file-explorer-content { flex:1; overflow:auto; padding:4px; }
+.file-list.grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(100px,1fr)); gap:10px; }
+.file-item { padding:4px; border-radius:3px; cursor:pointer; }
+.file-item:hover { background:#2a2d2e; }
+.file-item.selected { background:#094771; }
+.file-list.list .file-item { display:flex; align-items:center; }
+.file-icon { font-size:1.5em; margin-right:5px; }
+.empty-folder { padding:30px; text-align:center; color:#a0a0a0; }
+.context-menu {
+    position: fixed;
+    background: #252526;
+    border: 1px solid #3c3c3c;
+    z-index: 1000;
+    display: none;
+}
+.context-menu .context-menu-item { padding:5px 20px; cursor:pointer; }
+.context-menu .context-menu-item:hover { background:#2a2d2e; }
+.context-menu .context-menu-separator { height:1px; background:#3c3c3c; margin:5px 0; }


### PR DESCRIPTION
## Summary
- implement FileExplorerApp with navigation, context menu and simple operations
- add scoped CSS styles

## Testing
- `dotnet build wasm/HackerSimulator.Wasm.sln`
- `npm run build:debug` *(fails: webpack not found)*