### PR TITLE
Add basic dialog system

### DIFF
--- a/wasm/HackerSimulator.Wasm/Core/ShellService.cs
+++ b/wasm/HackerSimulator.Wasm/Core/ShellService.cs
@@ -15,6 +15,12 @@ namespace HackerSimulator.Wasm.Core
         private readonly Dictionary<string, Type> _processes = new();
         private readonly CommandProcessor _processor = new();
 
+        public T CreateObject<T>(ProcessBase? scope = null)
+        {
+            // scope parameter reserved for future use
+            return ActivatorUtilities.CreateInstance<T>(_provider);
+        }
+
         public ShellService(IServiceProvider provider, KernelService kernel)
         {
             _provider = provider;

--- a/wasm/HackerSimulator.Wasm/Dialogs/Dialog.cs
+++ b/wasm/HackerSimulator.Wasm/Dialogs/Dialog.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+using HackerSimulator.Wasm.Windows;
+
+namespace HackerSimulator.Wasm.Dialogs
+{
+    public abstract class Dialog<TResult> : WindowBase
+    {
+        private TaskCompletionSource<TResult?> _tcs = new();
+        private ProcessBase? _parent;
+
+        protected virtual TResult? DefaultResult => default;
+
+        public Task<TResult?> ShowDialog(ProcessBase? parentProcess = null)
+        {
+            _parent = parentProcess;
+            if (_parent is WindowBase pw)
+            {
+                pw.Lock();
+                pw.OnClosed += ParentClosed;
+            }
+
+            OnClosed += DialogClosed;
+            _ = Kernel.RunProcess(this, Array.Empty<string>());
+            return _tcs.Task;
+        }
+
+        private void ParentClosed(object? sender, EventArgs e)
+        {
+            base.Close();
+        }
+
+        private void DialogClosed(object? sender, EventArgs e)
+        {
+            if (_parent is WindowBase pw)
+            {
+                pw.Unlock();
+                pw.OnClosed -= ParentClosed;
+            }
+            if (!_tcs.Task.IsCompleted)
+                _tcs.TrySetResult(DefaultResult);
+        }
+
+        protected void CloseDialog(TResult? result)
+        {
+            base.Close();
+            _tcs.TrySetResult(result);
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Dialogs/FilePickerDialog.razor
+++ b/wasm/HackerSimulator.Wasm/Dialogs/FilePickerDialog.razor
@@ -1,0 +1,15 @@
+@inherits HackerSimulator.Wasm.Dialogs.Dialog<string?>
+<div class="file-picker-dialog">
+    <input @bind="_path" />
+    <button @onclick="Load">Go</button>
+    <ul>
+        @foreach(var entry in _entries)
+        {
+            <li @onclick="() => Select(entry)">@(entry.IsDirectory ? "[D]" : "[F]") @entry.Name</li>
+        }
+    </ul>
+    <div class="dialog-buttons">
+        <button @onclick="Ok" disabled="@(_selected == null)">Open</button>
+        <button @onclick="Cancel">Cancel</button>
+    </div>
+</div>

--- a/wasm/HackerSimulator.Wasm/Dialogs/FilePickerDialog.razor.cs
+++ b/wasm/HackerSimulator.Wasm/Dialogs/FilePickerDialog.razor.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Components;
+using HackerSimulator.Wasm.Core;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace HackerSimulator.Wasm.Dialogs
+{
+    public partial class FilePickerDialog : Dialog<string?>
+    {
+        [Inject] private FileSystemService FS { get; set; } = default!;
+
+        protected string _path = "/";
+        protected IEnumerable<FileSystemService.FileSystemEntry> _entries = new List<FileSystemService.FileSystemEntry>();
+        protected string? _selected;
+
+        protected override async Task OnInitializedAsync()
+        {
+            await base.OnInitializedAsync();
+            await Load();
+        }
+
+        protected async Task Load()
+        {
+            _entries = await FS.ReadDirectory(_path);
+        }
+
+        protected async Task Select(FileSystemService.FileSystemEntry entry)
+        {
+            if (entry.IsDirectory)
+            {
+                _path = FS.ResolvePath((_path == "/" ? string.Empty : _path) + "/" + entry.Name);
+                await Load();
+            }
+            else
+            {
+                _selected = (_path == "/" ? string.Empty : _path) + "/" + entry.Name;
+            }
+        }
+
+        protected void Ok() => CloseDialog(_selected);
+        protected void Cancel() => CloseDialog(null);
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Dialogs/FolderPickerDialog.razor
+++ b/wasm/HackerSimulator.Wasm/Dialogs/FolderPickerDialog.razor
@@ -1,0 +1,18 @@
+@inherits HackerSimulator.Wasm.Dialogs.Dialog<string?>
+<div class="folder-picker-dialog">
+    <input @bind="_path" />
+    <button @onclick="Load">Go</button>
+    <ul>
+        @foreach(var entry in _entries)
+        {
+            @if(entry.IsDirectory)
+            {
+                <li @onclick="() => Select(entry)">[D] @entry.Name</li>
+            }
+        }
+    </ul>
+    <div class="dialog-buttons">
+        <button @onclick="Ok">Select</button>
+        <button @onclick="Cancel">Cancel</button>
+    </div>
+</div>

--- a/wasm/HackerSimulator.Wasm/Dialogs/FolderPickerDialog.razor.cs
+++ b/wasm/HackerSimulator.Wasm/Dialogs/FolderPickerDialog.razor.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Components;
+using HackerSimulator.Wasm.Core;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace HackerSimulator.Wasm.Dialogs
+{
+    public partial class FolderPickerDialog : Dialog<string?>
+    {
+        [Inject] private FileSystemService FS { get; set; } = default!;
+
+        protected string _path = "/";
+        protected IEnumerable<FileSystemService.FileSystemEntry> _entries = new List<FileSystemService.FileSystemEntry>();
+
+        protected override async Task OnInitializedAsync()
+        {
+            await base.OnInitializedAsync();
+            await Load();
+        }
+
+        protected async Task Load()
+        {
+            _entries = await FS.ReadDirectory(_path);
+        }
+
+        protected async Task Select(FileSystemService.FileSystemEntry entry)
+        {
+            if (entry.IsDirectory)
+            {
+                _path = FS.ResolvePath((_path == "/" ? string.Empty : _path) + "/" + entry.Name);
+                await Load();
+            }
+        }
+
+        protected void Ok() => CloseDialog(_path);
+        protected void Cancel() => CloseDialog(null);
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Dialogs/MessageBoxDialog.razor
+++ b/wasm/HackerSimulator.Wasm/Dialogs/MessageBoxDialog.razor
@@ -1,0 +1,11 @@
+@inherits HackerSimulator.Wasm.Dialogs.Dialog<bool>
+<div class="message-box-dialog">
+    <p>@Message</p>
+    <div class="dialog-buttons">
+        <button @onclick="Ok">@OkText</button>
+        @if (ShowCancel)
+        {
+            <button @onclick="Cancel">@CancelText</button>
+        }
+    </div>
+</div>

--- a/wasm/HackerSimulator.Wasm/Dialogs/MessageBoxDialog.razor.cs
+++ b/wasm/HackerSimulator.Wasm/Dialogs/MessageBoxDialog.razor.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Components;
+
+namespace HackerSimulator.Wasm.Dialogs
+{
+    public partial class MessageBoxDialog : Dialog<bool>
+    {
+        [Parameter] public string Message { get; set; } = string.Empty;
+        [Parameter] public string OkText { get; set; } = "OK";
+        [Parameter] public string CancelText { get; set; } = "Cancel";
+        [Parameter] public bool ShowCancel { get; set; }
+
+        protected override bool DefaultResult => false;
+
+        protected void Ok() => CloseDialog(true);
+        protected void Cancel() => CloseDialog(false);
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Dialogs/PromptDialog.razor
+++ b/wasm/HackerSimulator.Wasm/Dialogs/PromptDialog.razor
@@ -1,0 +1,9 @@
+@inherits HackerSimulator.Wasm.Dialogs.Dialog<string?>
+<div class="prompt-dialog">
+    <p>@Message</p>
+    <input @bind="_value" />
+    <div class="dialog-buttons">
+        <button @onclick="Ok">Ok</button>
+        <button @onclick="Cancel">Cancel</button>
+    </div>
+</div>

--- a/wasm/HackerSimulator.Wasm/Dialogs/PromptDialog.razor.cs
+++ b/wasm/HackerSimulator.Wasm/Dialogs/PromptDialog.razor.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.Components;
+
+namespace HackerSimulator.Wasm.Dialogs
+{
+    public partial class PromptDialog : Dialog<string?>
+    {
+        [Parameter] public string Message { get; set; } = string.Empty;
+        [Parameter] public string? DefaultText { get; set; }
+
+        protected string _value = string.Empty;
+
+        protected override void OnInitialized()
+        {
+            base.OnInitialized();
+            _value = DefaultText ?? string.Empty;
+        }
+
+        protected void Ok() => CloseDialog(_value);
+        protected void Cancel() => CloseDialog(null);
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Windows/WindowBase.razor
+++ b/wasm/HackerSimulator.Wasm/Windows/WindowBase.razor
@@ -1,5 +1,5 @@
 @inherits HackerSimulator.Wasm.Core.ProcessBase
-<div class="hs-window @(IsActive ? "active" : "")" style="@Style" @onmousedown="HandleClick" @onmousemove="OnMouseMove" @onmouseup="StopDrag">
+<div class="hs-window @(IsActive ? "active" : "") @(Locked ? "locked" : "")" style="@Style" @onmousedown="HandleClick" @onmousemove="OnMouseMove" @onmouseup="StopDrag">
     <div class="hs-window-header" @ondblclick="ToggleMaximize" @onmousedown="StartDrag">
         @if (!string.IsNullOrEmpty(Icon))
         {

--- a/wasm/HackerSimulator.Wasm/Windows/WindowBase.razor.cs
+++ b/wasm/HackerSimulator.Wasm/Windows/WindowBase.razor.cs
@@ -32,11 +32,25 @@ namespace HackerSimulator.Wasm.Windows
 
         internal bool IsActive { get; private set; }
 
+        internal bool Locked { get; private set; }
+
         private bool _dragging;
         private double _startX;
         private double _startY;
         private double _startLeft;
         private double _startTop;
+
+        internal void Lock()
+        {
+            Locked = true;
+            StateHasChanged();
+        }
+
+        internal void Unlock()
+        {
+            Locked = false;
+            StateHasChanged();
+        }
 
         protected override void OnInitialized()
         {

--- a/wasm/HackerSimulator.Wasm/Windows/WindowBase.razor.css
+++ b/wasm/HackerSimulator.Wasm/Windows/WindowBase.razor.css
@@ -5,3 +5,4 @@
 .hs-window-buttons button { margin-left:4px; }
 .hs-window-content { overflow:auto; height:calc(100% - 30px); padding:4px; }
 .hs-window.active { border-color:#66f; }
+.hs-window.locked { pointer-events:none; opacity:0.6; }


### PR DESCRIPTION
## Summary
- support object creation in Shell with `CreateObject<T>()`
- extend `WindowBase` with lock support for modal dialogs
- implement generic `Dialog<TResult>` base class
- add `PromptDialog`, `MessageBoxDialog`, `FilePickerDialog` and `FolderPickerDialog`

## Testing
- `dotnet build wasm/HackerSimulator.Wasm/HackerSimulator.Wasm.csproj -clp:ErrorsOnly`