### PR TITLE
Add simple VS Code-like editor layout

### DIFF
--- a/wasm/HackerSimulator.Wasm/App/CodeEditorApp.razor
+++ b/wasm/HackerSimulator.Wasm/App/CodeEditorApp.razor
@@ -1,17 +1,41 @@
 @namespace HackerSimulator.Wasm.Apps
 @inherits HackerSimulator.Wasm.Windows.WindowBase
 
-<div class="code-editor">
-    <div class="toolbar">
-        <input type="text" @bind="_path" placeholder="/path/file" class="path-box" />
-        <select @bind="_language">
-            <option value="javascript">JavaScript</option>
-            <option value="csharp">C#</option>
-            <option value="html">HTML</option>
-            <option value="css">CSS</option>
-        </select>
-        <button @onclick="Open">Open</button>
-        <button @onclick="Save">Save</button>
+<div class="code-editor-layout">
+    <div class="activity-bar">
+        <button class="activity-btn">📁</button>
+        <button class="activity-btn">🔍</button>
+        <button class="activity-btn">🐞</button>
     </div>
-    <textarea class="editor" @bind="_content"></textarea>
+    <div class="editor-shell">
+        <div class="sidebar">
+            <FileTree RootPath="/home/user" OnFileSelected="OpenFile" />
+        </div>
+        <div class="editor-pane">
+            <div class="tab-bar">
+                @foreach (var tab in _tabs)
+                {
+                    <div class="tab @(tab == _activeTab ? "active" : null)" @onclick="() => Activate(tab)">
+                        <span class="tab-name">@System.IO.Path.GetFileName(tab.Path)</span>
+                        @if (tab.IsDirty)
+                        {
+                            <span class="dirty">●</span>
+                        }
+                        <button class="close-tab" @onclick="(e) => Close(tab)" @onclick:stopPropagation="true">x</button>
+                    </div>
+                }
+            </div>
+            @if (_activeTab != null)
+            {
+                <textarea class="editor" @bind="_activeTab.Content" @oninput="MarkDirty"></textarea>
+            }
+            else
+            {
+                <div class="no-file">Open a file to start editing</div>
+            }
+            <div class="terminal-panel">
+                <Terminal />
+            </div>
+        </div>
+    </div>
 </div>

--- a/wasm/HackerSimulator.Wasm/App/CodeEditorApp.razor.cs
+++ b/wasm/HackerSimulator.Wasm/App/CodeEditorApp.razor.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using HackerSimulator.Wasm.Core;
@@ -8,32 +11,67 @@ namespace HackerSimulator.Wasm.Apps
     {
         [Inject] private FileSystemService FS { get; set; } = default!;
 
-        private string _path = string.Empty;
-        private string _content = string.Empty;
-        private string _language = "javascript";
+        private class EditorTab
+        {
+            public string Path { get; set; } = string.Empty;
+            public string Content { get; set; } = string.Empty;
+            public string Language { get; set; } = "text";
+            public bool IsDirty { get; set; }
+        }
+
+        private readonly List<EditorTab> _tabs = new();
+        private EditorTab? _activeTab;
 
         protected override void OnInitialized()
         {
             base.OnInitialized();
             Title = "Code Editor";
-            _ = Open();
         }
 
-        private async Task Open()
+        private static string GuessLanguage(string path)
         {
-            if (string.IsNullOrWhiteSpace(_path))
-                return;
-            if (await FS.Exists(_path))
+            var ext = System.IO.Path.GetExtension(path).ToLowerInvariant();
+            return ext switch
             {
-                _content = await FS.ReadFile(_path);
-            }
+                ".cs" => "csharp",
+                ".html" or ".htm" => "html",
+                ".css" => "css",
+                _ => "javascript"
+            };
         }
+
+        private async Task OpenFile(string path)
+        {
+            var tab = _tabs.FirstOrDefault(t => t.Path == path);
+            if (tab == null)
+            {
+                var content = await FS.ReadFile(path);
+                tab = new EditorTab { Path = path, Content = content, Language = GuessLanguage(path) };
+                _tabs.Add(tab);
+            }
+            _activeTab = tab;
+        }
+
+        private void Activate(EditorTab tab) => _activeTab = tab;
 
         private async Task Save()
         {
-            if (string.IsNullOrWhiteSpace(_path))
-                return;
-            await FS.WriteFile(_path, _content);
+            if (_activeTab == null) return;
+            await FS.WriteFile(_activeTab.Path, _activeTab.Content);
+            _activeTab.IsDirty = false;
+        }
+
+        private void MarkDirty(ChangeEventArgs _)
+        {
+            if (_activeTab != null)
+                _activeTab.IsDirty = true;
+        }
+
+        private void Close(EditorTab tab)
+        {
+            _tabs.Remove(tab);
+            if (_activeTab == tab)
+                _activeTab = _tabs.LastOrDefault();
         }
     }
 }

--- a/wasm/HackerSimulator.Wasm/App/CodeEditorApp.razor.css
+++ b/wasm/HackerSimulator.Wasm/App/CodeEditorApp.razor.css
@@ -1,0 +1,89 @@
+.code-editor-layout {
+    display: flex;
+    height: 100%;
+}
+
+.activity-bar {
+    width: 40px;
+    background-color: #333;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding-top: 4px;
+}
+
+.activity-btn {
+    background: none;
+    border: none;
+    color: #fff;
+    margin: 4px 0;
+    cursor: pointer;
+}
+
+.editor-shell {
+    display: flex;
+    flex: 1;
+    height: 100%;
+}
+
+.sidebar {
+    width: 200px;
+    background-color: #252526;
+    color: #ddd;
+    padding: 4px;
+    overflow-y: auto;
+}
+
+.editor-pane {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.editor {
+    flex: 1;
+    width: 100%;
+    resize: none;
+}
+
+.tab-bar {
+    display: flex;
+    background-color: #2d2d30;
+    border-bottom: 1px solid #3c3c3c;
+}
+
+.tab {
+    display: flex;
+    align-items: center;
+    padding: 4px 8px;
+    cursor: pointer;
+    user-select: none;
+    color: #ddd;
+}
+
+.tab.active {
+    background-color: #3c3c3c;
+}
+
+.tab:hover {
+    background-color: #323234;
+}
+
+.tab-name { margin-right: 4px; }
+.dirty { color: #e0af68; margin-right: 4px; }
+.close-tab {
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+}
+
+.terminal-panel {
+    border-top: 1px solid #3c3c3c;
+    resize: vertical;
+    overflow: auto;
+    min-height: 100px;
+}
+
+/* Terminal component takes care of its own styling */
+

--- a/wasm/HackerSimulator.Wasm/Shared/FileTree/FileTree.razor
+++ b/wasm/HackerSimulator.Wasm/Shared/FileTree/FileTree.razor
@@ -1,0 +1,31 @@
+@namespace HackerSimulator.Wasm.Shared.FileTree
+@using HackerSimulator.Wasm.Core
+
+<ul class="file-tree-root">
+    @if (_entries != null)
+    {
+        @foreach (var e in _entries)
+        {
+            <FileTreeNode Entry="e.Entry" Path="e.Path" OnFileSelected="OnFileSelected" />
+        }
+    }
+</ul>
+
+@code {
+    [Inject] private FileSystemService FS { get; set; } = default!;
+
+    [Parameter] public string RootPath { get; set; } = "/";
+    [Parameter] public EventCallback<string> OnFileSelected { get; set; }
+
+    private List<(string Path, FileSystemService.FileSystemEntry Entry)>? _entries;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        var list = await FS.ReadDirectory(RootPath);
+        _entries = list
+            .OrderBy(e => e.Type)
+            .ThenBy(e => e.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(e => ((RootPath == "/" ? string.Empty : RootPath) + "/" + e.Name, e))
+            .ToList();
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Shared/FileTree/FileTree.razor.css
+++ b/wasm/HackerSimulator.Wasm/Shared/FileTree/FileTree.razor.css
@@ -1,0 +1,37 @@
+.file-tree-root {
+    list-style: none;
+    padding-left: 8px;
+    font-family: sans-serif;
+    color: #d4d4d4;
+}
+
+.file-tree-node {
+    list-style: none;
+}
+
+.node-header {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    padding: 2px 4px;
+    border-radius: 3px;
+}
+
+.node-header:hover {
+    background: #2a2d2e;
+}
+
+.node-toggle {
+    width: 12px;
+    display: inline-block;
+    margin-right: 4px;
+}
+
+.node-icon {
+    margin-right: 4px;
+}
+
+.node-children {
+    list-style: none;
+    padding-left: 16px;
+}

--- a/wasm/HackerSimulator.Wasm/Shared/FileTree/FileTreeNode.razor
+++ b/wasm/HackerSimulator.Wasm/Shared/FileTree/FileTreeNode.razor
@@ -1,0 +1,60 @@
+@namespace HackerSimulator.Wasm.Shared.FileTree
+@using HackerSimulator.Wasm.Core
+
+<li class="file-tree-node">
+    <div class="node-header" @onclick="OnClick">
+        @if (Entry.IsDirectory)
+        {
+            <span class="node-toggle">@(_expanded ? "▼" : "▶")</span>
+            <span class="node-icon">📁</span>
+            <span class="node-name">@Entry.Name</span>
+        }
+        else
+        {
+            <span class="node-toggle"></span>
+            <span class="node-icon">📄</span>
+            <span class="node-name">@Entry.Name</span>
+        }
+    </div>
+    @if (_expanded && Entry.IsDirectory && _children != null)
+    {
+        <ul class="node-children">
+            @foreach (var child in _children)
+            {
+                <FileTreeNode Entry="child.Entry" Path="child.Path" OnFileSelected="OnFileSelected" />
+            }
+        </ul>
+    }
+</li>
+
+@code {
+    [Inject] private FileSystemService FS { get; set; } = default!;
+
+    [Parameter] public FileSystemService.FileSystemEntry Entry { get; set; } = default!;
+    [Parameter] public string Path { get; set; } = "/";
+    [Parameter] public EventCallback<string> OnFileSelected { get; set; }
+
+    private bool _expanded;
+    private List<(string Path, FileSystemService.FileSystemEntry Entry)>? _children;
+
+    private async Task OnClick()
+    {
+        if (Entry.IsDirectory)
+        {
+            _expanded = !_expanded;
+            if (_expanded && _children == null)
+            {
+                var list = await FS.ReadDirectory(Path);
+                _children = list
+                    .OrderBy(e => e.Type)
+                    .ThenBy(e => e.Name, StringComparer.OrdinalIgnoreCase)
+                    .Select(e => ((Path == "/" ? string.Empty : Path) + "/" + e.Name, e))
+                    .ToList();
+            }
+        }
+        else
+        {
+            await OnFileSelected.InvokeAsync(Path);
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Shared/Terminal/Terminal.razor
+++ b/wasm/HackerSimulator.Wasm/Shared/Terminal/Terminal.razor
@@ -1,0 +1,9 @@
+@namespace HackerSimulator.Wasm.Shared.Terminal
+
+<div class="terminal-container" @onclick="FocusInput">
+    <pre class="terminal-output">@_display</pre>
+    <div class="terminal-input-line">
+        <span class="terminal-prompt">@Prompt</span>
+        <input @ref="_inputRef" @bind="_input" @bind:event="oninput" @onkeydown="HandleInputKey" class="terminal-input" />
+    </div>
+</div>

--- a/wasm/HackerSimulator.Wasm/Shared/Terminal/Terminal.razor.cs
+++ b/wasm/HackerSimulator.Wasm/Shared/Terminal/Terminal.razor.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+
+namespace HackerSimulator.Wasm.Shared.Terminal
+{
+    public partial class Terminal : ComponentBase
+    {
+        [Inject] private HackerSimulator.Wasm.Core.ShellService Shell { get; set; } = default!;
+
+        private readonly List<string> _lines = new();
+        private string _input = string.Empty;
+        private int _historyIndex = -1;
+        private readonly List<string> _history = new();
+        private ElementReference _inputRef;
+        private string _cwd = "~";
+
+        private string _display => string.Join("\n", _lines);
+        private string Prompt => $"user@hacker-machine:{_cwd}$ ";
+
+        protected override void OnInitialized()
+        {
+            base.OnInitialized();
+            _lines.Add("Welcome to HackerOS Terminal");
+            _lines.Add("Type \"help\" for a list of commands");
+            _lines.Add(string.Empty);
+        }
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            await base.OnAfterRenderAsync(firstRender);
+            if (firstRender)
+            {
+                await FocusInput();
+                AppendPrompt();
+            }
+        }
+
+        private async Task FocusInput()
+        {
+            await _inputRef.FocusAsync();
+        }
+
+        private void AppendPrompt()
+        {
+            _lines.Add(Prompt);
+            StateHasChanged();
+        }
+
+        private async Task HandleInputKey(KeyboardEventArgs e)
+        {
+            if (e.Key == "Enter")
+            {
+                await ExecuteCommand();
+            }
+            else if (e.Key == "ArrowUp")
+            {
+                NavigateHistory(1);
+            }
+            else if (e.Key == "ArrowDown")
+            {
+                NavigateHistory(-1);
+            }
+        }
+
+        private void NavigateHistory(int direction)
+        {
+            if (_history.Count == 0)
+                return;
+
+            if (direction > 0)
+            {
+                if (_historyIndex < _history.Count - 1)
+                    _historyIndex++;
+            }
+            else
+            {
+                if (_historyIndex >= 0)
+                    _historyIndex--;
+            }
+
+            if (_historyIndex >= 0 && _historyIndex < _history.Count)
+            {
+                _input = _history[_history.Count - 1 - _historyIndex];
+            }
+            else
+            {
+                _input = string.Empty;
+            }
+        }
+
+        private async Task ExecuteCommand()
+        {
+            var command = _input.Trim();
+            _lines[^1] = Prompt + _input;
+            if (!string.IsNullOrWhiteSpace(command))
+            {
+                _history.Add(command);
+            }
+            _input = string.Empty;
+            _historyIndex = -1;
+
+            if (!string.IsNullOrWhiteSpace(command))
+            {
+                var output = await RunShellCommand(command);
+                if (!string.IsNullOrEmpty(output))
+                {
+                    foreach (var line in output.Split('\n'))
+                    {
+                        _lines.Add(line.Replace("\r", string.Empty));
+                    }
+                }
+            }
+
+            AppendPrompt();
+        }
+
+        private async Task<string> RunShellCommand(string command)
+        {
+            using var stdout = new StringWriter();
+            using var stderr = new StringWriter();
+            var ctx = new HackerSimulator.Wasm.Commands.CommandContext
+            {
+                Stdin = new StringReader(string.Empty),
+                Stdout = stdout,
+                Stderr = stderr,
+                Env = new Dictionary<string, string>
+                {
+                    {"PWD", _cwd},
+                    {"USER", "user"}
+                }
+            };
+
+            await Shell.ExecuteCommand(command, ctx);
+            if (ctx.Env.TryGetValue("PWD", out var newCwd))
+            {
+                _cwd = newCwd;
+            }
+
+            var output = stdout.ToString();
+            var error = stderr.ToString();
+            return string.IsNullOrEmpty(error) ? output : output + error;
+        }
+    }
+}
+

--- a/wasm/HackerSimulator.Wasm/Shared/Terminal/Terminal.razor.css
+++ b/wasm/HackerSimulator.Wasm/Shared/Terminal/Terminal.razor.css
@@ -1,0 +1,52 @@
+.terminal-container {
+    background-color: #1e1e1e;
+    color: #cccccc;
+    font-family: Consolas, 'Courier New', monospace;
+    padding: 10px;
+    overflow-y: auto;
+    height: 25%;
+}
+
+.terminal-output {
+    white-space: pre-wrap;
+}
+
+.terminal-input-line {
+    display: flex;
+}
+
+.terminal-input {
+    background-color: transparent;
+    border: none;
+    width: 100%;
+    color: #cccccc;
+    outline: none;
+}
+
+.terminal-prompt {
+    color: #569cd6;
+    margin-right: 4px;
+}
+
+.terminal-cursor {
+    background-color: #cccccc;
+    animation: blink 1s step-end infinite;
+}
+
+@keyframes blink {
+    from, to { opacity: 1; }
+    50% { opacity: 0; }
+}
+
+.terminal-header {
+    background-color: #252526;
+    padding: 5px;
+    display: flex;
+    align-items: center;
+}
+
+.terminal-header button,
+.terminal-header .icon {
+    margin-right: 4px;
+}
+

--- a/wasm/HackerSimulator.Wasm/_Imports.razor
+++ b/wasm/HackerSimulator.Wasm/_Imports.razor
@@ -7,3 +7,5 @@
 @using HackerSimulator.Wasm.Shared
 @using HackerSimulator.Wasm.Core
 @using HackerSimulator.Wasm.Windows
+@using HackerSimulator.Wasm.Shared.Terminal
+@using HackerSimulator.Wasm.Shared.FileTree


### PR DESCRIPTION
## Summary
- implement basic CodeEditor layout with sidebar file tree and tabbed editor
- integrate reusable Terminal component in resizable panel
- style tab bar, sidebar and terminal
- expose new FileTree namespace globally

## Testing
- `dotnet build wasm/HackerSimulator.Wasm/HackerSimulator.Wasm.csproj -nologo`