### PR TITLE
Add BlazorMonaco editor

### DIFF
--- a/wasm/HackerSimulator.Wasm/App/CodeEditorApp.razor
+++ b/wasm/HackerSimulator.Wasm/App/CodeEditorApp.razor
@@ -27,7 +27,13 @@
             </div>
             @if (_activeTab != null)
             {
-                <textarea class="editor" @bind="_activeTab.Content" @oninput="MarkDirty"></textarea>
+                <MonacoEditor class="editor"
+                              @ref="_editor"
+                              Value="_activeTab.Content"
+                              Language="_activeTab.Language"
+                              Theme="vs-dark"
+                              OnDidChangeModelContent="EditorChanged"
+                              Options="_editorOptions" />
             }
             else
             {

--- a/wasm/HackerSimulator.Wasm/App/CodeEditorApp.razor.cs
+++ b/wasm/HackerSimulator.Wasm/App/CodeEditorApp.razor.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using HackerSimulator.Wasm.Core;
+using BlazorMonaco;
 
 namespace HackerSimulator.Wasm.Apps
 {
@@ -21,6 +22,11 @@ namespace HackerSimulator.Wasm.Apps
 
         private readonly List<EditorTab> _tabs = new();
         private EditorTab? _activeTab;
+        private MonacoEditor? _editor;
+        private readonly StandaloneEditorConstructionOptions _editorOptions = new()
+        {
+            AutomaticLayout = true
+        };
 
         protected override void OnInitialized()
         {
@@ -50,9 +56,23 @@ namespace HackerSimulator.Wasm.Apps
                 _tabs.Add(tab);
             }
             _activeTab = tab;
+            StateHasChanged();
         }
 
-        private void Activate(EditorTab tab) => _activeTab = tab;
+        private void Activate(EditorTab tab)
+        {
+            _activeTab = tab;
+            StateHasChanged();
+        }
+
+        private async Task EditorChanged()
+        {
+            if (_activeTab != null && _editor != null)
+            {
+                _activeTab.Content = await _editor.GetValue();
+                _activeTab.IsDirty = true;
+            }
+        }
 
         private async Task Save()
         {
@@ -61,11 +81,6 @@ namespace HackerSimulator.Wasm.Apps
             _activeTab.IsDirty = false;
         }
 
-        private void MarkDirty(ChangeEventArgs _)
-        {
-            if (_activeTab != null)
-                _activeTab.IsDirty = true;
-        }
 
         private void Close(EditorTab tab)
         {

--- a/wasm/HackerSimulator.Wasm/HackerSimulator.Wasm.csproj
+++ b/wasm/HackerSimulator.Wasm/HackerSimulator.Wasm.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0-preview.1" />
+    <PackageReference Include="BlazorMonaco" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Update="Views/**/*.cshtml" CopyToOutputDirectory="Always" />

--- a/wasm/HackerSimulator.Wasm/_Imports.razor
+++ b/wasm/HackerSimulator.Wasm/_Imports.razor
@@ -9,3 +9,4 @@
 @using HackerSimulator.Wasm.Windows
 @using HackerSimulator.Wasm.Shared.Terminal
 @using HackerSimulator.Wasm.Shared.FileTree
+@using BlazorMonaco


### PR DESCRIPTION
## Summary
- integrate BlazorMonaco editor in CodeEditorApp
- add BlazorMonaco NuGet package
- expose BlazorMonaco namespaces via `_Imports.razor`

## Testing
- `dotnet build wasm/HackerSimulator.Wasm.sln -c Release` *(fails: No route to host for NuGet packages)*