### PR TITLE
Add desktop and shared file list

### DIFF
--- a/wasm/HackerSimulator.Wasm/App/FileExplorerApp.razor
+++ b/wasm/HackerSimulator.Wasm/App/FileExplorerApp.razor
@@ -1,6 +1,7 @@
 @namespace HackerSimulator.Wasm.Apps
 @inherits HackerSimulator.Wasm.Windows.WindowBase
 @inject HackerSimulator.Wasm.Core.ShellService Shell
+@using HackerSimulator.Wasm.Shared
 
 <div class="file-explorer-app" @onclick="HideMenu">
     <div class="file-explorer-toolbar">
@@ -14,8 +15,8 @@
             <input class="path-input" @bind="_path" @bind:event="oninput" @onkeydown="OnPathKeyDown" />
         </div>
         <div class="view-options">
-            <button class="view-btn @(ViewMode == ViewModes.Grid ? "active" : null)" @onclick="() => SetView(ViewModes.Grid)">Grid</button>
-            <button class="view-btn @(ViewMode == ViewModes.List ? "active" : null)" @onclick="() => SetView(ViewModes.List)">List</button>
+            <button class="view-btn @(ViewMode == FileListViewMode.Grid ? "active" : null)" @onclick="() => SetView(FileListViewMode.Grid)">Grid</button>
+            <button class="view-btn @(ViewMode == FileListViewMode.List ? "active" : null)" @onclick="() => SetView(FileListViewMode.List)">List</button>
             <button class="view-btn show-hidden @(ShowHidden ? "active" : null)" @onclick="ToggleHidden">Hidden</button>
         </div>
     </div>
@@ -35,23 +36,14 @@
             </div>
         </div>
         <div class="file-explorer-content" @oncontextmenu="ShowBackgroundMenu">
-            <div class="file-list @(ViewMode == ViewModes.Grid ? "grid" : "list")">
-                @if (_entries.Count == 0)
-                {
-                    <div class="empty-folder">This folder is empty</div>
-                }
-                else
-                {
-                    @foreach (var entry in _entries)
-                    {
-                        var path = EntryPath(entry);
-                        <div class="file-item @(Selected.Contains(path) ? "selected" : null)" @onclick="() => Select(entry)" @ondblclick="() => Open(entry)" @oncontextmenu="e => ShowContextMenu(e, entry)">
-                            <span class="file-icon">@(entry.IsDirectory ? "📁" : "📄")</span>
-                            <span class="file-name">@entry.Name</span>
-                        </div>
-                    }
-                }
-            </div>
+            <FileList Entries="_entries"
+                      Selected="Selected"
+                      ViewMode="ViewMode"
+                      EntryPath="EntryPath"
+                      IconProvider="GetIcon"
+                      OnSelect="Select"
+                      OnOpen="Open"
+                      OnContextMenu="OnListContextMenu" />
         </div>
     </div>
 

--- a/wasm/HackerSimulator.Wasm/Pages/Index.razor
+++ b/wasm/HackerSimulator.Wasm/Pages/Index.razor
@@ -1,3 +1,4 @@
 @page "/"
-<h1>Hacker Simulator Desktop</h1>
-<p>Select an application from the menu.</p>
+@using HackerSimulator.Wasm.Shared
+
+<Desktop />

--- a/wasm/HackerSimulator.Wasm/Shared/Desktop/Desktop.razor
+++ b/wasm/HackerSimulator.Wasm/Shared/Desktop/Desktop.razor
@@ -1,0 +1,98 @@
+@namespace HackerSimulator.Wasm.Shared
+@using HackerSimulator.Wasm.Core
+
+<div class="desktop">
+    <FileList Entries="_entries"
+              Selected="_selected"
+              ViewMode="FileListViewMode.Grid"
+              EntryPath="GetPath"
+              IconProvider="GetIcon"
+              OnSelect="Select"
+              OnOpen="Open" />
+</div>
+
+@code {
+    [Inject] private FileSystemService FS { get; set; } = default!;
+    [Inject] private ShellService Shell { get; set; } = default!;
+
+    private const string DesktopPath = "/home/user/Desktop";
+
+    private List<FileSystemService.FileSystemEntry> _entries = new();
+    private HashSet<string> _selected = new();
+    private readonly Dictionary<string, ShortcutData> _shortcuts = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        await Load();
+    }
+
+    private async Task Load()
+    {
+        var items = await FS.ReadDirectory(DesktopPath);
+        _entries = items.OrderBy(e => e.Type).ThenBy(e => e.Name).ToList();
+        _shortcuts.Clear();
+        foreach (var e in _entries)
+        {
+            var p = GetPath(e);
+            if (!e.IsDirectory && p.EndsWith(".hlnk", StringComparison.OrdinalIgnoreCase))
+            {
+                try
+                {
+                    var json = await FS.ReadFile(p);
+                    var sc = System.Text.Json.JsonSerializer.Deserialize<ShortcutData>(json);
+                    if (sc != null) _shortcuts[p] = sc;
+                }
+                catch { }
+            }
+        }
+    }
+
+    private string GetPath(FileSystemService.FileSystemEntry e) => $"{DesktopPath}/{e.Name}";
+
+    private string GetIcon(FileSystemService.FileSystemEntry e, string path)
+    {
+        if (e.IsDirectory) return "📁";
+        if (_shortcuts.TryGetValue(path, out var sc) && !string.IsNullOrEmpty(sc.Icon))
+            return sc.Icon!;
+        if (path.EndsWith(".hlnk", StringComparison.OrdinalIgnoreCase)) return "🔗";
+        return "📄";
+    }
+
+    private void Select(FileSystemService.FileSystemEntry e)
+    {
+        var path = GetPath(e);
+        _selected.Clear();
+        _selected.Add(path);
+    }
+
+    private async Task Open(FileSystemService.FileSystemEntry e)
+    {
+        var path = GetPath(e);
+        if (e.IsDirectory)
+        {
+            await Shell.Run("fileexplorerapp", new[] { path });
+        }
+        else if (path.EndsWith(".hlnk", StringComparison.OrdinalIgnoreCase))
+        {
+            if (!_shortcuts.TryGetValue(path, out var sc))
+            {
+                try
+                {
+                    var json = await FS.ReadFile(path);
+                    sc = System.Text.Json.JsonSerializer.Deserialize<ShortcutData>(json);
+                }
+                catch { }
+            }
+            if (sc != null && !string.IsNullOrWhiteSpace(sc.Command))
+            {
+                await Shell.Run(sc.Command, sc.Args ?? Array.Empty<string>());
+            }
+        }
+        else
+        {
+            await Shell.Run("texteditorapp", new[] { path });
+        }
+    }
+
+    private record ShortcutData(string Command, string[]? Args, string? Icon);
+}

--- a/wasm/HackerSimulator.Wasm/Shared/Desktop/Desktop.razor.css
+++ b/wasm/HackerSimulator.Wasm/Shared/Desktop/Desktop.razor.css
@@ -1,0 +1,3 @@
+.desktop {
+    padding: 10px;
+}

--- a/wasm/HackerSimulator.Wasm/Shared/FileList/FileList.razor
+++ b/wasm/HackerSimulator.Wasm/Shared/FileList/FileList.razor
@@ -1,0 +1,35 @@
+@namespace HackerSimulator.Wasm.Shared
+@using HackerSimulator.Wasm.Core
+@using Microsoft.AspNetCore.Components.Web
+
+<div class="file-list @(ViewMode == FileListViewMode.Grid ? "grid" : "list")">
+    @if (Entries.Count == 0)
+    {
+        <div class="empty-folder">This folder is empty</div>
+    }
+    else
+    {
+        @foreach (var entry in Entries)
+        {
+            var path = EntryPath(entry);
+            <div class="file-item @(Selected?.Contains(path) == true ? "selected" : null)"
+                 @onclick="() => OnSelect.InvokeAsync(entry)"
+                 @ondblclick="() => OnOpen.InvokeAsync(entry)"
+                 @oncontextmenu="e => OnContextMenu.InvokeAsync((e, entry))">
+                <span class="file-icon">@IconProvider(entry, path)</span>
+                <span class="file-name">@entry.Name</span>
+            </div>
+        }
+    }
+</div>
+
+@code {
+    [Parameter] public IReadOnlyList<FileSystemService.FileSystemEntry> Entries { get; set; } = Array.Empty<FileSystemService.FileSystemEntry>();
+    [Parameter] public HashSet<string>? Selected { get; set; }
+    [Parameter] public FileListViewMode ViewMode { get; set; }
+    [Parameter] public Func<FileSystemService.FileSystemEntry, string> EntryPath { get; set; } = e => e.Name;
+    [Parameter] public Func<FileSystemService.FileSystemEntry, string, string> IconProvider { get; set; } = (e, p) => e.IsDirectory ? "📁" : "📄";
+    [Parameter] public EventCallback<FileSystemService.FileSystemEntry> OnSelect { get; set; }
+    [Parameter] public EventCallback<FileSystemService.FileSystemEntry> OnOpen { get; set; }
+    [Parameter] public EventCallback<(MouseEventArgs, FileSystemService.FileSystemEntry?)> OnContextMenu { get; set; }
+}

--- a/wasm/HackerSimulator.Wasm/Shared/FileList/FileList.razor.css
+++ b/wasm/HackerSimulator.Wasm/Shared/FileList/FileList.razor.css
@@ -1,0 +1,15 @@
+.file-list.grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill,minmax(100px,1fr));
+    gap: 10px;
+}
+.file-item {
+    padding: 4px;
+    border-radius: 3px;
+    cursor: pointer;
+}
+.file-item:hover { background:#2a2d2e; }
+.file-item.selected { background:#094771; }
+.file-list.list .file-item { display:flex; align-items:center; }
+.file-icon { font-size:1.5em; margin-right:5px; }
+.empty-folder { padding:30px; text-align:center; color:#a0a0a0; }

--- a/wasm/HackerSimulator.Wasm/Shared/FileList/FileListViewMode.cs
+++ b/wasm/HackerSimulator.Wasm/Shared/FileList/FileListViewMode.cs
@@ -1,0 +1,8 @@
+namespace HackerSimulator.Wasm.Shared
+{
+    public enum FileListViewMode
+    {
+        List,
+        Grid
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared `FileList` component with CSS
- create `Desktop` component using `FileList`
- export `FileListViewMode` enum
- refactor `FileExplorerApp` to use new `FileList` and handle `.hlnk` shortcut files
- show new desktop page

## Testing
- `dotnet build` *(fails: MonacoEditor missing)*