### PR TITLE
Add basic file type handling service

### DIFF
--- a/wasm/HackerSimulator.Wasm/App/CodeEditorApp.razor.cs
+++ b/wasm/HackerSimulator.Wasm/App/CodeEditorApp.razor.cs
@@ -8,6 +8,7 @@ using BlazorMonaco;
 
 namespace HackerSimulator.Wasm.Apps
 {
+    [OpenFileType("js", "ts", "cs", "json", "html", "css")]
     public partial class CodeEditorApp : Windows.WindowBase
     {
         [Inject] private FileSystemService FS { get; set; } = default!;

--- a/wasm/HackerSimulator.Wasm/App/FileExplorerApp.razor.cs
+++ b/wasm/HackerSimulator.Wasm/App/FileExplorerApp.razor.cs
@@ -14,6 +14,7 @@ namespace HackerSimulator.Wasm.Apps
     public partial class FileExplorerApp : Windows.WindowBase
     {
         [Inject] private FileSystemService FS { get; set; } = default!;
+        [Inject] private FileTypeService FileTypes { get; set; } = default!;
 
         private string _path = "/home/user";
         private List<FileSystemService.FileSystemEntry> _entries = new();
@@ -114,7 +115,7 @@ namespace HackerSimulator.Wasm.Apps
             if (_shortcuts.TryGetValue(path, out var sc) && !string.IsNullOrEmpty(sc.Icon))
                 return sc.Icon!;
             if (path.EndsWith(".hlnk", StringComparison.OrdinalIgnoreCase)) return "🔗";
-            return "📄";
+            return FileTypes.GetIcon(path);
         }
 
         private void Select(FileSystemService.FileSystemEntry entry)
@@ -154,7 +155,7 @@ namespace HackerSimulator.Wasm.Apps
             }
             else
             {
-                await Shell.Run("texteditorapp", new[] { path });
+                await Shell.OpenFile(path);
             }
         }
 

--- a/wasm/HackerSimulator.Wasm/App/TextEditorApp.razor.cs
+++ b/wasm/HackerSimulator.Wasm/App/TextEditorApp.razor.cs
@@ -4,6 +4,7 @@ using HackerSimulator.Wasm.Core;
 
 namespace HackerSimulator.Wasm.Apps
 {
+    [OpenFileType("txt", "md", "doc", "docx")]
     public partial class TextEditorApp : Windows.WindowBase
     {
         [Inject] private FileSystemService FS { get; set; } = default!;

--- a/wasm/HackerSimulator.Wasm/Core/AutoRunService.cs
+++ b/wasm/HackerSimulator.Wasm/Core/AutoRunService.cs
@@ -28,6 +28,9 @@ namespace HackerSimulator.Wasm.Core
             _started = true;
             var fs = _services.GetRequiredService<FileSystemService>();
             await fs.InitAsync();
+
+            var ft = _services.GetRequiredService<FileTypeService>();
+            ft.RegisterFromAttributes();
         }
     }
 }

--- a/wasm/HackerSimulator.Wasm/Core/FileTypeService.cs
+++ b/wasm/HackerSimulator.Wasm/Core/FileTypeService.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace HackerSimulator.Wasm.Core
+{
+    /// <summary>
+    /// Service storing associations between file extensions, icons and
+    /// default applications.
+    /// </summary>
+    public class FileTypeService
+    {
+        public record FileTypeInfo(string App, string Icon);
+
+        private readonly Dictionary<string, FileTypeInfo> _types = new(StringComparer.OrdinalIgnoreCase);
+        private readonly FileTypeInfo _default = new("texteditorapp", "📄");
+
+        public FileTypeService()
+        {
+            RegisterDefaults();
+        }
+
+        public void Register(string extension, string defaultApp, string icon = "📄")
+        {
+            if (string.IsNullOrWhiteSpace(extension) || string.IsNullOrWhiteSpace(defaultApp))
+                return;
+            extension = extension.TrimStart('.').ToLowerInvariant();
+            _types[extension] = new FileTypeInfo(defaultApp.ToLowerInvariant(), icon);
+        }
+
+        public FileTypeInfo GetInfo(string filename)
+        {
+            var ext = GetExtension(filename);
+            if (ext != null && _types.TryGetValue(ext, out var info))
+                return info;
+            return _default;
+        }
+
+        public string GetDefaultApp(string filename) => GetInfo(filename).App;
+        public string GetIcon(string filename) => GetInfo(filename).Icon;
+
+        private static string? GetExtension(string filename)
+        {
+            var idx = filename.LastIndexOf('.');
+            return idx < 0 ? null : filename[(idx + 1)..].ToLowerInvariant();
+        }
+
+        private void RegisterDefaults()
+        {
+            Register("txt", "texteditorapp", "📝");
+            Register("md", "texteditorapp", "📝");
+            Register("js", "codeeditorapp", "📜");
+            Register("ts", "codeeditorapp", "📜");
+            Register("json", "codeeditorapp", "📊");
+            Register("html", "codeeditorapp", "🌐");
+            Register("css", "codeeditorapp", "🎨");
+            Register("png", "fileexplorerapp", "🖼️");
+            Register("jpg", "fileexplorerapp", "🖼️");
+            Register("jpeg", "fileexplorerapp", "🖼️");
+            Register("gif", "fileexplorerapp", "🖼️");
+        }
+
+        public void RegisterFromAttributes()
+        {
+            var assembly = typeof(FileTypeService).Assembly;
+            foreach (var type in assembly.GetTypes())
+            {
+                var attrs = type.GetCustomAttributes(typeof(OpenFileTypeAttribute), false)
+                    .Cast<OpenFileTypeAttribute>();
+                foreach (var attr in attrs)
+                {
+                    foreach (var ext in attr.Extensions)
+                    {
+                        Register(ext, type.Name.ToLowerInvariant());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Core/OpenFileTypeAttribute.cs
+++ b/wasm/HackerSimulator.Wasm/Core/OpenFileTypeAttribute.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace HackerSimulator.Wasm.Core
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public sealed class OpenFileTypeAttribute : Attribute
+    {
+        public string[] Extensions { get; }
+        public OpenFileTypeAttribute(params string[] extensions)
+        {
+            Extensions = extensions;
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Core/ShellService.cs
+++ b/wasm/HackerSimulator.Wasm/Core/ShellService.cs
@@ -14,6 +14,7 @@ namespace HackerSimulator.Wasm.Core
         private readonly KernelService _kernel;
         private readonly Dictionary<string, Type> _processes = new();
         private readonly CommandProcessor _processor = new();
+        private readonly FileTypeService _fileTypes;
 
         public T CreateObject<T>(ProcessBase? scope = null)
         {
@@ -21,10 +22,11 @@ namespace HackerSimulator.Wasm.Core
             return ActivatorUtilities.CreateInstance<T>(_provider);
         }
 
-        public ShellService(IServiceProvider provider, KernelService kernel)
+        public ShellService(IServiceProvider provider, KernelService kernel, FileTypeService fileTypes)
         {
             _provider = provider;
             _kernel = kernel;
+            _fileTypes = fileTypes;
             DiscoverProcesses();
             RegisterBuiltInCommands();
             DiscoverCommands();
@@ -96,5 +98,11 @@ namespace HackerSimulator.Wasm.Core
 
         public IEnumerable<ICommandModule> GetCommands() => _processor.GetCommands();
         public ICommandModule? GetCommand(string name) => _processor.GetCommand(name);
+
+        public Task OpenFile(string path)
+        {
+            var app = _fileTypes.GetDefaultApp(path);
+            return Run(app, new[] { path });
+        }
     }
 }

--- a/wasm/HackerSimulator.Wasm/Program.cs
+++ b/wasm/HackerSimulator.Wasm/Program.cs
@@ -17,6 +17,7 @@ namespace HackerSimulator.Wasm
             builder.Services.AddSingleton<AliasService>();
             builder.Services.AddSingleton<ShellService>();
             builder.Services.AddSingleton<FileSystemService>();
+            builder.Services.AddSingleton<FileTypeService>();
 
             builder.Services.AddSingleton<AutoRunService>();
 

--- a/wasm/HackerSimulator.Wasm/Shared/Desktop/Desktop.razor
+++ b/wasm/HackerSimulator.Wasm/Shared/Desktop/Desktop.razor
@@ -14,6 +14,7 @@
 @code {
     [Inject] private FileSystemService FS { get; set; } = default!;
     [Inject] private ShellService Shell { get; set; } = default!;
+    [Inject] private FileTypeService FileTypes { get; set; } = default!;
 
     private const string DesktopPath = "/home/user/Desktop";
 
@@ -55,7 +56,7 @@
         if (_shortcuts.TryGetValue(path, out var sc) && !string.IsNullOrEmpty(sc.Icon))
             return sc.Icon!;
         if (path.EndsWith(".hlnk", StringComparison.OrdinalIgnoreCase)) return "🔗";
-        return "📄";
+        return FileTypes.GetIcon(path);
     }
 
     private void Select(FileSystemService.FileSystemEntry e)
@@ -90,7 +91,7 @@
         }
         else
         {
-            await Shell.Run("texteditorapp", new[] { path });
+            await Shell.OpenFile(path);
         }
     }
 


### PR DESCRIPTION
## Summary
- implement `FileTypeService` and `OpenFileTypeAttribute`
- register file types on start-up via `AutoRunService`
- allow `ShellService.OpenFile` to run default app for a file
- show icons using the new service in Desktop and File Explorer
- decorate CodeEditorApp and TextEditorApp with supported file types
- wire up file type injection and update usages

## Testing
- `dotnet build wasm/HackerSimulator.Wasm/HackerSimulator.Wasm.csproj -v:m` *(fails: BlazorMonaco and other packages missing)*