### PR TITLE
Add start menu to Blazor WASM

### DIFF
--- a/wasm/HackerSimulator.Wasm/App/CalculatorApp.razor.cs
+++ b/wasm/HackerSimulator.Wasm/App/CalculatorApp.razor.cs
@@ -1,7 +1,9 @@
 using System;
+using HackerSimulator.Wasm.Core;
 
 namespace HackerSimulator.Wasm.Apps
 {
+    [AppIcon("fa:calculator")]
     public partial class CalculatorApp : Windows.WindowBase
     {
         private readonly string[][] _layout = new[]

--- a/wasm/HackerSimulator.Wasm/App/CodeEditorApp.razor.cs
+++ b/wasm/HackerSimulator.Wasm/App/CodeEditorApp.razor.cs
@@ -9,6 +9,7 @@ using BlazorMonaco;
 namespace HackerSimulator.Wasm.Apps
 {
     [OpenFileType("js", "ts", "cs", "json", "html", "css")]
+    [AppIcon("fa:code")]
     public partial class CodeEditorApp : Windows.WindowBase
     {
         [Inject] private FileSystemService FS { get; set; } = default!;

--- a/wasm/HackerSimulator.Wasm/App/ErrorLogViewerApp.razor.cs
+++ b/wasm/HackerSimulator.Wasm/App/ErrorLogViewerApp.razor.cs
@@ -4,6 +4,7 @@ using HackerSimulator.Wasm.Core;
 
 namespace HackerSimulator.Wasm.Apps
 {
+    [AppIcon("fa:triangle-exclamation")]
     public partial class ErrorLogViewerApp : Windows.WindowBase
     {
         [Inject] private FileSystemService FS { get; set; } = default!;

--- a/wasm/HackerSimulator.Wasm/App/FileExplorerApp.razor.cs
+++ b/wasm/HackerSimulator.Wasm/App/FileExplorerApp.razor.cs
@@ -7,10 +7,12 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using HackerSimulator.Wasm.Dialogs;
 using HackerSimulator.Wasm.Core;
+using HackerSimulator.Wasm.Core;
 using HackerSimulator.Wasm.Shared;
 
 namespace HackerSimulator.Wasm.Apps
 {
+    [AppIcon("fa:folder")]
     public partial class FileExplorerApp : Windows.WindowBase
     {
         [Inject] private FileSystemService FS { get; set; } = default!;

--- a/wasm/HackerSimulator.Wasm/App/SettingsApp.razor.cs
+++ b/wasm/HackerSimulator.Wasm/App/SettingsApp.razor.cs
@@ -1,9 +1,11 @@
 using System.Threading.Tasks;
 using Microsoft.JSInterop;
 using Microsoft.AspNetCore.Components;
+using HackerSimulator.Wasm.Core;
 
 namespace HackerSimulator.Wasm.Apps
 {
+    [AppIcon("fa:cog")]
     public partial class SettingsApp : Windows.WindowBase
     {
         [Inject] private IJSRuntime JS { get; set; } = default!;

--- a/wasm/HackerSimulator.Wasm/App/SystemMonitorApp.razor.cs
+++ b/wasm/HackerSimulator.Wasm/App/SystemMonitorApp.razor.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
 
 namespace HackerSimulator.Wasm.Apps
 {
+    [AppIcon("fa:chart-line")]
     public partial class SystemMonitorApp : Windows.WindowBase, IDisposable
     {
         private Timer? _timer;

--- a/wasm/HackerSimulator.Wasm/App/TerminalApp.razor.cs
+++ b/wasm/HackerSimulator.Wasm/App/TerminalApp.razor.cs
@@ -4,12 +4,14 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using HackerSimulator.Wasm.Core;
 using Microsoft.AspNetCore.Components.Web;
 using HackerSimulator.Wasm.Commands;
 using HackerSimulator.Wasm.Windows;
 
 namespace HackerSimulator.Wasm.Apps
 {
+    [AppIcon("fa:terminal")] 
     public partial class TerminalApp : WindowBase
     {
         private readonly List<string> _lines = new();

--- a/wasm/HackerSimulator.Wasm/App/TextEditorApp.razor.cs
+++ b/wasm/HackerSimulator.Wasm/App/TextEditorApp.razor.cs
@@ -5,6 +5,7 @@ using HackerSimulator.Wasm.Core;
 namespace HackerSimulator.Wasm.Apps
 {
     [OpenFileType("txt", "md", "doc", "docx")]
+    [AppIcon("fa:file-lines")]
     public partial class TextEditorApp : Windows.WindowBase
     {
         [Inject] private FileSystemService FS { get; set; } = default!;

--- a/wasm/HackerSimulator.Wasm/App/WebBrowserApp.razor.cs
+++ b/wasm/HackerSimulator.Wasm/App/WebBrowserApp.razor.cs
@@ -5,9 +5,11 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 using HackerSimulator.Wasm.Web;
+using HackerSimulator.Wasm.Core;
 
 namespace HackerSimulator.Wasm.Apps
 {
+    [AppIcon("fa:globe")]
     public partial class WebBrowserApp : Windows.WindowBase, IAsyncDisposable
     {
         [Inject] private HackerHttpClient Http { get; set; } = default!;

--- a/wasm/HackerSimulator.Wasm/Core/AppIconAttribute.cs
+++ b/wasm/HackerSimulator.Wasm/Core/AppIconAttribute.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace HackerSimulator.Wasm.Core
+{
+    /// <summary>
+    /// Attribute to specify the default icon for an application or process
+    /// using the <see cref="Icon"/> helper string format.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class AppIconAttribute : Attribute
+    {
+        public AppIconAttribute(string icon)
+        {
+            Icon = icon;
+        }
+
+        /// <summary>
+        /// Icon string in the IconHelper descriptor format (e.g. "fa:save").
+        /// </summary>
+        public string Icon { get; }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Core/ApplicationService.cs
+++ b/wasm/HackerSimulator.Wasm/Core/ApplicationService.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace HackerSimulator.Wasm.Core
+{
+    /// <summary>
+    /// Discovers window based applications and exposes basic metadata
+    /// like command name, display name and icon.
+    /// </summary>
+    public class ApplicationService
+    {
+        public record AppInfo(string Command, string Name, string Icon);
+
+        private readonly List<AppInfo> _apps = new();
+
+        public ApplicationService()
+        {
+            DiscoverApplications();
+        }
+
+        private void DiscoverApplications()
+        {
+            var asm = Assembly.GetExecutingAssembly();
+            foreach (var type in asm.GetTypes())
+            {
+                if (type.IsAbstract) continue;
+                if (!typeof(Windows.WindowBase).IsAssignableFrom(type)) continue;
+
+                var cmd = type.Name.ToLowerInvariant();
+                var name = ToDisplayName(type.Name);
+                var iconAttr = type.GetCustomAttribute<AppIconAttribute>();
+                var icon = iconAttr?.Icon ?? "fa:window-maximize";
+
+                _apps.Add(new AppInfo(cmd, name, icon));
+            }
+
+            _apps.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static string ToDisplayName(string typeName)
+        {
+            if (typeName.EndsWith("App"))
+                typeName = typeName.Substring(0, typeName.Length - 3);
+            var name = System.Text.RegularExpressions.Regex.Replace(typeName, "([a-z])([A-Z])", "$1 $2");
+            return name;
+        }
+
+        public IReadOnlyList<AppInfo> GetApps() => _apps;
+
+        public AppInfo? GetApp(string command) => _apps.FirstOrDefault(a => a.Command == command);
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Core/FileSystemService.cs
+++ b/wasm/HackerSimulator.Wasm/Core/FileSystemService.cs
@@ -307,6 +307,22 @@ namespace HackerSimulator.Wasm.Core
             return Task.FromResult(_entries.TryGetValue(path, out var rec) && rec.Entry.IsBinary);
         }
 
+        /// <summary>
+        /// Search for files and directories containing the given term.
+        /// Returns full paths for all matches.
+        /// </summary>
+        public Task<IEnumerable<string>> Search(string term)
+        {
+            if (string.IsNullOrWhiteSpace(term))
+                return Task.FromResult(Enumerable.Empty<string>());
+
+            var results = _entries.Values
+                .Where(e => e.Entry.Name.Contains(term, StringComparison.OrdinalIgnoreCase))
+                .Select(e => e.Path);
+
+            return Task.FromResult(results);
+        }
+
         public class FileStats
         {
             public bool IsDirectory { get; set; }

--- a/wasm/HackerSimulator.Wasm/Program.cs
+++ b/wasm/HackerSimulator.Wasm/Program.cs
@@ -19,6 +19,9 @@ namespace HackerSimulator.Wasm
             builder.Services.AddSingleton<FileSystemService>();
             builder.Services.AddSingleton<FileTypeService>();
 
+            // Register application discovery service
+            builder.Services.AddSingleton<ApplicationService>();
+
             builder.Services.AddSingleton<AutoRunService>();
 
             builder.Services.AddSingleton<NetworkService>();

--- a/wasm/HackerSimulator.Wasm/Shared/StartMenu/StartMenu.razor
+++ b/wasm/HackerSimulator.Wasm/Shared/StartMenu/StartMenu.razor
@@ -1,0 +1,109 @@
+@implements IDisposable
+@inject ApplicationService AppService
+@inject FileSystemService FS
+@inject ShellService Shell
+@using HackerSimulator.Wasm.Core
+
+<div class="start-menu @(Visible ? "visible" : null)">
+    <input class="start-search" placeholder="Search" @bind="_search" @bind:event="oninput" />
+    @if (!string.IsNullOrWhiteSpace(_search))
+    {
+        <ul class="search-results">
+            @foreach (var app in _appResults)
+            {
+                <li @onclick="() => Launch(app.Command)">@((MarkupString)Icon.Parse(app.Icon).ToHtml(new { @class="result-icon" }))<span>@app.Name</span></li>
+            }
+            @foreach (var file in _fileResults)
+            {
+                <li @onclick="() => OpenFile(file)"><span class="result-icon">📄</span><span>@System.IO.Path.GetFileName(file)</span></li>
+            }
+        </ul>
+    }
+    else
+    {
+        <div class="pinned-apps">
+            @foreach (var app in PinnedApps)
+            {
+                <button class="app-btn" @onclick="() => Launch(app.Command)">@((MarkupString)Icon.Parse(app.Icon).ToHtml(new { @class="app-icon" }))<span>@app.Name</span></button>
+            }
+        </div>
+        <div class="all-apps">
+            <button class="toggle-all" @onclick="ToggleAll">@(_showAll ? "Hide" : "All Apps")</button>
+            @if (_showAll)
+            {
+                <ul class="all-apps-list">
+                    @foreach (var app in _allApps)
+                    {
+                        <li @onclick="() => Launch(app.Command)">@((MarkupString)Icon.Parse(app.Icon).ToHtml(new { @class="result-icon" }))<span>@app.Name</span></li>
+                    }
+                </ul>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter] public bool Visible { get; set; }
+    [Parameter] public EventCallback<bool> VisibleChanged { get; set; }
+
+    private string _search = string.Empty;
+    private List<ApplicationService.AppInfo> _allApps = new();
+    private List<ApplicationService.AppInfo> _pinned = new() { "terminalapp", "fileexplorerapp", "settingsapp" }
+        .Select(c => AppService.GetApp(c)!)
+        .Where(a => a != null).ToList();
+    private List<ApplicationService.AppInfo> _appResults = new();
+    private List<string> _fileResults = new();
+    private bool _showAll;
+
+    private IEnumerable<ApplicationService.AppInfo> PinnedApps => _pinned;
+
+    protected override void OnInitialized()
+    {
+        _allApps = AppService.GetApps().ToList();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        await UpdateSearch();
+    }
+
+    private async Task UpdateSearch()
+    {
+        if (string.IsNullOrWhiteSpace(_search))
+        {
+            _appResults.Clear();
+            _fileResults.Clear();
+            return;
+        }
+
+        _appResults = _allApps.Where(a => a.Name.Contains(_search, StringComparison.OrdinalIgnoreCase)).ToList();
+        _fileResults = (await FS.Search(_search)).Take(20).ToList();
+    }
+
+    private void ToggleAll()
+    {
+        _showAll = !_showAll;
+    }
+
+    private async Task Launch(string command)
+    {
+        await Shell.Run(command, Array.Empty<string>());
+        await Close();
+    }
+
+    private async Task OpenFile(string path)
+    {
+        await Shell.OpenFile(path);
+        await Close();
+    }
+
+    public async Task Close()
+    {
+        Visible = false;
+        await VisibleChanged.InvokeAsync(false);
+    }
+
+    public void Dispose()
+    {
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Shared/StartMenu/StartMenu.razor.css
+++ b/wasm/HackerSimulator.Wasm/Shared/StartMenu/StartMenu.razor.css
@@ -1,0 +1,62 @@
+.start-menu {
+    position: absolute;
+    bottom: 40px;
+    left: 4px;
+    width: 260px;
+    background: #222;
+    color: #eee;
+    border: 1px solid #444;
+    border-radius: 4px;
+    padding: 6px;
+    display: none;
+    flex-direction: column;
+    z-index: 1000;
+}
+.start-menu.visible {
+    display: flex;
+}
+.start-search {
+    width: 100%;
+    margin-bottom: 6px;
+}
+.pinned-apps {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 6px;
+}
+.app-btn {
+    width: 60px;
+    height: 60px;
+    background: #333;
+    border: none;
+    color: #fff;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    border-radius: 3px;
+}
+.app-icon {
+    font-size: 20px;
+}
+.all-apps-list, .search-results {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    max-height: 200px;
+    overflow: auto;
+}
+.all-apps-list li, .search-results li {
+    padding: 4px;
+    cursor: pointer;
+}
+.all-apps-list li:hover, .search-results li:hover {
+    background: #2a2d2e;
+}
+.result-icon {
+    margin-right: 6px;
+}
+.toggle-all {
+    margin-bottom: 6px;
+}

--- a/wasm/HackerSimulator.Wasm/Shared/Taskbar.razor
+++ b/wasm/HackerSimulator.Wasm/Shared/Taskbar.razor
@@ -1,8 +1,10 @@
 @implements IDisposable
 @inject WindowManagerService WindowManager
+@using HackerSimulator.Wasm.Shared.StartMenu
 
 <div class="taskbar">
-    <button class="start-button">Start</button>
+    <button class="start-button" @onclick="ToggleMenu">Start</button>
+    <StartMenu.StartMenu Visible="_menuVisible" VisibleChanged="OnMenuVisibleChanged" />
     @foreach (var win in _windows)
     {
         <button class="task-button @(win == _active ? "active" : "")" @onclick="() => Activate(win)">
@@ -18,6 +20,7 @@
 @code {
     private readonly List<WindowBase> _windows = new();
     private WindowBase? _active;
+    private bool _menuVisible;
 
     protected override void OnInitialized()
     {
@@ -54,6 +57,16 @@
             win.Restore();
         }
         win.Activate();
+    }
+
+    private void ToggleMenu()
+    {
+        _menuVisible = !_menuVisible;
+    }
+
+    private void OnMenuVisibleChanged(bool visible)
+    {
+        _menuVisible = visible;
     }
 
     public void Dispose()

--- a/wasm/HackerSimulator.Wasm/_Imports.razor
+++ b/wasm/HackerSimulator.Wasm/_Imports.razor
@@ -9,4 +9,5 @@
 @using HackerSimulator.Wasm.Windows
 @using HackerSimulator.Wasm.Shared.Terminal
 @using HackerSimulator.Wasm.Shared.FileTree
+@using HackerSimulator.Wasm.Shared.StartMenu
 @using BlazorMonaco


### PR DESCRIPTION
## Summary
- create `AppIconAttribute` and `ApplicationService` for app metadata
- expose file system `Search` API
- implement `StartMenu` component and styles
- integrate start menu with the taskbar
- annotate apps with `[AppIcon]`

## Testing
- `dotnet build wasm/HackerSimulator.Wasm/HackerSimulator.Wasm.csproj -nologo` *(fails: Blazor dependencies missing)*