### PR TITLE
Enable MudBlazor and icon fonts

### DIFF
--- a/wasm/HackerSimulator.Wasm/App/FileExplorerApp.razor.cs
+++ b/wasm/HackerSimulator.Wasm/App/FileExplorerApp.razor.cs
@@ -110,9 +110,8 @@ namespace HackerSimulator.Wasm.Apps
         private string EntryPath(FileSystemService.FileSystemEntry e)
             => (_path == "/" ? string.Empty : _path) + "/" + e.Name;
 
-        private string GetIcon(FileSystemService.FileSystemEntry e)
+        private string GetIcon(FileSystemService.FileSystemEntry e, string path)
         {
-            var path = EntryPath(e);
             if (e.IsDirectory) return "📁";
             if (_shortcuts.TryGetValue(path, out var sc) && !string.IsNullOrEmpty(sc.Icon))
                 return sc.Icon!;

--- a/wasm/HackerSimulator.Wasm/Core/Icon.cs
+++ b/wasm/HackerSimulator.Wasm/Core/Icon.cs
@@ -44,6 +44,12 @@ namespace HackerSimulator.Wasm.Core
                 {
                     "fa" => new Icon(IconType.FontAwesome, value),
                     "iconic" => new Icon(IconType.Iconic, value),
+                    "mat" => new Icon(IconType.Material, value),
+                    "material" => new Icon(IconType.Material, value),
+                    "mud" => new Icon(IconType.MudBlazor, value),
+                    "lucide" => new Icon(IconType.Lucide, value),
+                    "iconscout" => new Icon(IconType.IconScout, value),
+                    "emoji" => new Icon(IconType.Emoji, value),
                     "image" => new Icon(IconType.Image, value),
                     "ico" => new Icon(IconType.Image, value),
                     "data" => new Icon(IconType.Data, value),
@@ -70,6 +76,11 @@ namespace HackerSimulator.Wasm.Core
             {
                 IconType.FontAwesome => "fa",
                 IconType.Iconic => "iconic",
+                IconType.Material => "mat",
+                IconType.MudBlazor => "mud",
+                IconType.Lucide => "lucide",
+                IconType.IconScout => "iconscout",
+                IconType.Emoji => "emoji",
                 IconType.Data => "data",
                 _ => "image"
             };
@@ -87,6 +98,11 @@ namespace HackerSimulator.Wasm.Core
             {
                 IconType.FontAwesome => $"<i class=\"fa fa-{Value}\"{attrs}></i>",
                 IconType.Iconic => $"<span class=\"iconic-{Value}\"{attrs}></span>",
+                IconType.Material => $"<span class=\"material-icons\"{attrs}>{Value}</span>",
+                IconType.MudBlazor => $"<span class=\"mud-icon material-icons\"{attrs}>{Value}</span>",
+                IconType.Lucide => $"<i class=\"lucide lucide-{Value}\"{attrs}></i>",
+                IconType.IconScout => $"<i class=\"uil uil-{Value}\"{attrs}></i>",
+                IconType.Emoji => $"<span{attrs}>{Value}</span>",
                 IconType.Data => $"<img src=\"{EnsureDataPrefix(Value)}\"{attrs} />",
                 _ => $"<img src=\"{Value}\"{attrs} />"
             };
@@ -129,6 +145,11 @@ namespace HackerSimulator.Wasm.Core
     {
         FontAwesome,
         Iconic,
+        Material,
+        MudBlazor,
+        Lucide,
+        IconScout,
+        Emoji,
         Image,
         Data
     }

--- a/wasm/HackerSimulator.Wasm/Program.cs
+++ b/wasm/HackerSimulator.Wasm/Program.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Services;
 using HackerSimulator.Wasm.Core;
 using HackerSimulator.Wasm.Web;
 using HackerSimulator.Wasm.Web.Controllers;
@@ -12,6 +14,7 @@ namespace HackerSimulator.Wasm
         {
             var builder = WebAssemblyHostBuilder.CreateDefault(args);
             builder.RootComponents.Add<App>("#app");
+            builder.RootComponents.Add<HeadOutlet>("head::after");
 
             builder.Services.AddSingleton<KernelService>();
             builder.Services.AddSingleton<AliasService>();
@@ -30,6 +33,7 @@ namespace HackerSimulator.Wasm
 
             builder.Services.AddSingleton<HomeController>();
             builder.Services.AddSingleton<Windows.WindowManagerService>();
+            builder.Services.AddMudServices();
 
 
             var host = builder.Build();

--- a/wasm/HackerSimulator.Wasm/Shared/StartMenu/StartMenu.razor
+++ b/wasm/HackerSimulator.Wasm/Shared/StartMenu/StartMenu.razor
@@ -48,9 +48,7 @@
 
     private string _search = string.Empty;
     private List<ApplicationService.AppInfo> _allApps = new();
-    private List<ApplicationService.AppInfo> _pinned = new() { "terminalapp", "fileexplorerapp", "settingsapp" }
-        .Select(c => AppService.GetApp(c)!)
-        .Where(a => a != null).ToList();
+    private List<ApplicationService.AppInfo> _pinned = new();
     private List<ApplicationService.AppInfo> _appResults = new();
     private List<string> _fileResults = new();
     private bool _showAll;
@@ -60,6 +58,10 @@
     protected override void OnInitialized()
     {
         _allApps = AppService.GetApps().ToList();
+        _pinned = new[] { "terminalapp", "fileexplorerapp", "settingsapp" }
+            .Select(c => AppService.GetApp(c)!)
+            .Where(a => a != null)
+            .ToList();
     }
 
     protected override async Task OnParametersSetAsync()

--- a/wasm/HackerSimulator.Wasm/_Imports.razor
+++ b/wasm/HackerSimulator.Wasm/_Imports.razor
@@ -11,3 +11,4 @@
 @using HackerSimulator.Wasm.Shared.FileTree
 @using HackerSimulator.Wasm.Shared.StartMenu
 @using BlazorMonaco
+@using MudBlazor

--- a/wasm/HackerSimulator.Wasm/wwwroot/index.html
+++ b/wasm/HackerSimulator.Wasm/wwwroot/index.html
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hacker Simulator</title>
     <base href="/" />
+    <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/lucide-static@0.373.0/font/Lucide.css" rel="stylesheet" />
+    <link href="https://unicons.iconscout.com/release/v4.0.8/css/line.css" rel="stylesheet" />
 </head>
 <body>
     <div id="app">Loading...</div>

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -6,6 +6,8 @@ Core services including a simple kernel, shell, and in-memory file system are pr
 
 Additional OS emulation layers are being ported from the TypeScript version. A basic network stack and DNS server have been implemented in C# under `Core/NetworkService.cs`.
 
+The WebAssembly frontend uses [MudBlazor](https://mudblazor.com/) components and several icon fonts including FontAwesome, Google Material Icons, Lucide and Iconscout.
+
 To build and run the application (once .NET 9 SDK is installed):
 
 ```bash


### PR DESCRIPTION
## Summary
- register MudBlazor services and head outlet
- load MudBlazor, FontAwesome, Material, Lucide and Iconscout icon fonts
- extend Icon helper to support multiple icon sets and emoji icons
- update StartMenu initialization
- fix FileExplorer icon provider

## Testing
- `dotnet build wasm/HackerSimulator.Wasm.sln -v:m`