### PR TITLE
Add folder workspace and multi-terminal support

### DIFF
--- a/wasm/HackerSimulator.Wasm/App/CodeEditorApp.razor
+++ b/wasm/HackerSimulator.Wasm/App/CodeEditorApp.razor
@@ -4,8 +4,9 @@
 @using BlazorMonaco
 @using BlazorMonaco.Editor
 @using BlazorMonaco.Languages
+@using MudBlazor
 
-<div class="code-editor-layout">
+<div class="code-editor-layout" tabindex="0" @onkeydown="HandleKey">
     <div class="activity-bar">
         <button class="activity-btn">📁</button>
         <button class="activity-btn">🔍</button>
@@ -13,9 +14,17 @@
     </div>
     <div class="editor-shell">
         <div class="sidebar">
-            <FileTree RootPath="/home/user" OnFileSelected="OpenFile" />
+            <FileTree RootPath="@_workingDirectory" OnFileSelected="OpenFile" />
         </div>
         <div class="editor-pane">
+            <div class="menu-bar">
+                <MudMenu Label="File">
+                    <MudMenuItem OnClick="Save">Save</MudMenuItem>
+                    <MudMenuItem OnClick="SaveWorkspace">Save Workspace</MudMenuItem>
+                    <MudMenuItem OnClick="LoadWorkspace">Load Workspace</MudMenuItem>
+                    <MudMenuItem OnClick="OpenFolder">Open Folder</MudMenuItem>
+                </MudMenu>
+            </div>
             <div class="tab-bar">
                 @foreach (var tab in _tabs)
                 {
@@ -45,7 +54,19 @@
                 <div class="no-file">Open a file to start editing</div>
             }
             <div class="terminal-panel">
-                <Terminal />
+                <div class="terminal-tabs">
+                    @for (int i = 0; i < _terminalCount; i++)
+                    {
+                        <div class="terminal-tab @(i == _activeTerminal ? "active" : null)" @onclick="() => ActivateTerminal(i)">Terminal @(i + 1)</div>
+                    }
+                    <button class="terminal-add" @onclick="AddTerminal">+</button>
+                </div>
+                @for (int i = 0; i < _terminalCount; i++)
+                {
+                    <div class="terminal-container @(i == _activeTerminal ? "active" : null)">
+                        <Terminal @ref="_terminalRefs[i]" WorkingDirectory="@_workingDirectory" />
+                    </div>
+                }
             </div>
         </div>
     </div>

--- a/wasm/HackerSimulator.Wasm/App/CodeEditorApp.razor.css
+++ b/wasm/HackerSimulator.Wasm/App/CodeEditorApp.razor.css
@@ -40,6 +40,12 @@
     flex-direction: column;
 }
 
+.menu-bar {
+    background-color: #2d2d30;
+    color: #ddd;
+    padding: 4px;
+}
+
 .editor {
     flex: 1;
     width: 100%;
@@ -83,6 +89,37 @@
     resize: vertical;
     overflow: auto;
     min-height: 100px;
+}
+
+.terminal-tabs {
+    display: flex;
+    background-color: #2d2d30;
+    border-bottom: 1px solid #3c3c3c;
+}
+
+.terminal-tab {
+    padding: 4px 8px;
+    cursor: pointer;
+    color: #ddd;
+}
+
+.terminal-tab.active {
+    background-color: #3c3c3c;
+}
+
+.terminal-add {
+    background: none;
+    border: none;
+    color: #ddd;
+    cursor: pointer;
+}
+
+.terminal-container {
+    display: none;
+}
+
+.terminal-container.active {
+    display: block;
 }
 
 /* Terminal component takes care of its own styling */

--- a/wasm/HackerSimulator.Wasm/Shared/Terminal/Terminal.razor.cs
+++ b/wasm/HackerSimulator.Wasm/Shared/Terminal/Terminal.razor.cs
@@ -11,6 +11,8 @@ namespace HackerSimulator.Wasm.Shared.Terminal
     {
         [Inject] private HackerSimulator.Wasm.Core.ShellService Shell { get; set; } = default!;
 
+        [Parameter] public string WorkingDirectory { get; set; } = "~";
+
         private readonly List<string> _lines = new();
         private string _input = string.Empty;
         private int _historyIndex = -1;
@@ -24,6 +26,7 @@ namespace HackerSimulator.Wasm.Shared.Terminal
         protected override void OnInitialized()
         {
             base.OnInitialized();
+            _cwd = WorkingDirectory;
             _lines.Add("Welcome to HackerOS Terminal");
             _lines.Add("Type \"help\" for a list of commands");
             _lines.Add(string.Empty);

--- a/wasm/HackerSimulator.Wasm/_Imports.razor
+++ b/wasm/HackerSimulator.Wasm/_Imports.razor
@@ -11,3 +11,4 @@
 @using HackerSimulator.Wasm.Shared.FileTree
 @using HackerSimulator.Wasm.Shared.StartMenu
 @using BlazorMonaco
+@using MudBlazor


### PR DESCRIPTION
## Summary
- integrate MudBlazor globally
- allow Terminal component starting directory configuration
- extend CodeEditor with menu bar, folder picker, workspace save/load, and multi-terminal tabs
- handle Ctrl+S for saving
- style updates for new menu and terminal tabs

## Testing
- `dotnet build wasm/HackerSimulator.Wasm.sln -c Release` *(fails: No overload for 'GetIcon' matches delegate)*