### PR TITLE
Add HackPaint editor skeleton

### DIFF
--- a/src/apps/hack-paint.less
+++ b/src/apps/hack-paint.less
@@ -1,0 +1,28 @@
+.hack-paint-toolbar {
+  display: flex;
+  gap: 5px;
+  padding: 5px;
+  background: #333;
+}
+.hack-paint-toolbar button {
+  background: #555;
+  color: #fff;
+  border: none;
+  padding: 4px 8px;
+  cursor: pointer;
+}
+.hack-paint-toolbar input[type="color"],
+.hack-paint-toolbar input[type="range"] {
+  margin-left: 5px;
+}
+.hack-paint-canvas-container {
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background: #222;
+}
+.hack-paint-canvas {
+  background: #fff;
+  display: block;
+  margin: 0 auto;
+}

--- a/src/apps/hack-paint.ts
+++ b/src/apps/hack-paint.ts
@@ -1,0 +1,133 @@
+import { GuiApplication } from '../core/gui-application';
+import { OS } from '../core/os';
+
+/**
+ * HackPaint - minimal image editor application
+ * Provides basic drawing and image loading/export features.
+ */
+export class HackPaintApp extends GuiApplication {
+  private canvas: HTMLCanvasElement | null = null;
+  private ctx: CanvasRenderingContext2D | null = null;
+  private colorInput: HTMLInputElement | null = null;
+  private sizeInput: HTMLInputElement | null = null;
+  private fileInput: HTMLInputElement | null = null;
+  private scale: number = 1;
+  private drawing = false;
+
+  constructor(os: OS) {
+    super(os);
+  }
+
+  protected getApplicationName(): string {
+    return 'hack-paint';
+  }
+
+  protected initApplication(): void {
+    if (!this.container) return;
+    this.render();
+    this.setupEvents();
+  }
+
+  private render(): void {
+    if (!this.container) return;
+    this.container.innerHTML = `
+      <div class="hack-paint-toolbar">
+        <button class="open-btn">Open</button>
+        <button class="save-btn">Save</button>
+        <button class="zoom-in-btn">Zoom In</button>
+        <button class="zoom-out-btn">Zoom Out</button>
+        <input type="color" class="color-input" value="#000000" />
+        <input type="range" class="size-input" min="1" max="50" value="5" />
+        <input type="file" class="file-input" accept="image/*" style="display:none;" />
+      </div>
+      <div class="hack-paint-canvas-container">
+        <canvas class="hack-paint-canvas" width="800" height="600"></canvas>
+      </div>
+    `;
+    this.canvas = this.container.querySelector('.hack-paint-canvas');
+    this.colorInput = this.container.querySelector('.color-input');
+    this.sizeInput = this.container.querySelector('.size-input');
+    this.fileInput = this.container.querySelector('.file-input');
+    if (this.canvas) this.ctx = this.canvas.getContext('2d');
+  }
+
+  private setupEvents(): void {
+    if (!this.container || !this.canvas || !this.ctx) return;
+    const openBtn = this.container.querySelector('.open-btn');
+    const saveBtn = this.container.querySelector('.save-btn');
+    const zoomInBtn = this.container.querySelector('.zoom-in-btn');
+    const zoomOutBtn = this.container.querySelector('.zoom-out-btn');
+
+    openBtn?.addEventListener('click', () => this.fileInput?.click());
+    this.fileInput?.addEventListener('change', (e) => this.loadImage(e));
+    saveBtn?.addEventListener('click', () => this.saveImage());
+    zoomInBtn?.addEventListener('click', () => this.zoom(1.25));
+    zoomOutBtn?.addEventListener('click', () => this.zoom(0.8));
+
+    this.canvas.addEventListener('mousedown', (e) => this.startDraw(e));
+    this.canvas.addEventListener('mousemove', (e) => this.draw(e));
+    this.canvas.addEventListener('mouseup', () => this.stopDraw());
+    this.canvas.addEventListener('mouseleave', () => this.stopDraw());
+  }
+
+  private loadImage(e: Event): void {
+    const input = e.target as HTMLInputElement;
+    if (!input.files || input.files.length === 0 || !this.ctx) return;
+    const file = input.files[0];
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => {
+        if (!this.canvas) return;
+        this.canvas.width = img.width;
+        this.canvas.height = img.height;
+        this.ctx!.drawImage(img, 0, 0);
+      };
+      if (typeof reader.result === 'string') {
+        img.src = reader.result;
+      }
+    };
+    reader.readAsDataURL(file);
+  }
+
+  private saveImage(): void {
+    if (!this.canvas) return;
+    const url = this.canvas.toDataURL('image/png');
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'image.png';
+    a.click();
+  }
+
+  private zoom(factor: number): void {
+    if (!this.canvas) return;
+    this.scale *= factor;
+    this.canvas.style.transform = `scale(${this.scale})`;
+  }
+
+  private startDraw(e: MouseEvent): void {
+    if (!this.ctx || !this.canvas) return;
+    this.drawing = true;
+    this.ctx.beginPath();
+    const rect = this.canvas.getBoundingClientRect();
+    this.ctx.moveTo((e.clientX - rect.left) / this.scale, (e.clientY - rect.top) / this.scale);
+  }
+
+  private draw(e: MouseEvent): void {
+    if (!this.drawing || !this.ctx || !this.canvas) return;
+    const rect = this.canvas.getBoundingClientRect();
+    const color = this.colorInput?.value || '#000000';
+    const size = parseInt(this.sizeInput?.value || '5', 10);
+    this.ctx.strokeStyle = color;
+    this.ctx.lineWidth = size;
+    this.ctx.lineCap = 'round';
+    this.ctx.lineTo((e.clientX - rect.left) / this.scale, (e.clientY - rect.top) / this.scale);
+    this.ctx.stroke();
+  }
+
+  private stopDraw(): void {
+    if (!this.drawing || !this.ctx) return;
+    this.drawing = false;
+    this.ctx.closePath();
+  }
+}

--- a/src/core/app-manager.ts
+++ b/src/core/app-manager.ts
@@ -180,6 +180,16 @@ export class AppManager {
       launchable: true,
       singleton: true
     });
+
+    // HackPaint image editor
+    this.registerApp({
+      id: 'hack-paint',
+      name: 'HackPaint',
+      description: 'Simple image editor',
+      icon: '🖌️',
+      launchable: true,
+      singleton: true
+    });
   }
 
   /**
@@ -320,6 +330,9 @@ export class AppManager {
         break;
       case 'theme-editor':
         this.loadThemeEditorUI(contentElement,windowId, args);
+        break;
+      case 'hack-paint':
+        this.loadHackPaintUI(contentElement,windowId, args);
         break;
       default:
         contentElement.innerHTML = `<div style="padding: 20px;">App '${appId}' UI not implemented yet.</div>`;
@@ -507,6 +520,18 @@ export class AppManager {
     }).catch(error => {
       console.error('Failed to load error log viewer app:', error);
       contentElement.innerHTML = '<div style="padding: 20px;">Failed to load error log viewer app.</div>';
+    });
+  }
+
+  private loadHackPaintUI(contentElement: HTMLElement, windowId: string, args: string[] = []): void {
+    contentElement.innerHTML = '<div class="hack-paint"></div>';
+
+    import('../apps/hack-paint').then(module => {
+      const hackPaintApp = new module.HackPaintApp(this.os);
+      hackPaintApp.init(contentElement.querySelector('.hack-paint')!, windowId, args);
+    }).catch(error => {
+      console.error('Failed to load HackPaint app:', error);
+      contentElement.innerHTML = '<div style="padding: 20px;">Failed to load HackPaint app.</div>';
     });
   }
   /**

--- a/src/styles/apps.less
+++ b/src/styles/apps.less
@@ -12,6 +12,7 @@
 @import "../apps/settings.less";
 @import "../apps/error-log-viewer.less";
 @import "../apps/theme-editor.less";
+@import "../apps/hack-paint.less";
 
 
 // Add other apps as they are created


### PR DESCRIPTION
## Summary
- add minimal `HackPaint` application with basic canvas drawing
- include new styles for HackPaint
- register the application in the AppManager
- import HackPaint styles

## Testing
- `npm run tsc:debug` *(fails: Cannot find module 'monaco-editor', etc.)*
- `npm run build:debug` *(fails: webpack not found)*