### PR TITLE
Add Open With submenu in File Explorer

### DIFF
--- a/wasm/HackerSimulator.Wasm/App/FileExplorerApp.razor
+++ b/wasm/HackerSimulator.Wasm/App/FileExplorerApp.razor
@@ -1,6 +1,7 @@
 @namespace HackerSimulator.Wasm.Apps
 @inherits HackerSimulator.Wasm.Windows.WindowBase
 @inject HackerSimulator.Wasm.Core.ShellService Shell
+@using MudBlazor
 @using HackerSimulator.Wasm.Shared
 
 <div class="file-explorer-app" @onclick="HideMenu">
@@ -53,6 +54,17 @@
             @if (_menuEntry != null)
             {
                 <div class="context-menu-item" @onclick='() => ContextAction("open")'>Open</div>
+                <MudMenu AnchorOrigin="Origin.TopRight" TransformOrigin="Origin.TopLeft" Class="context-submenu">
+                    <ActivatorContent>
+                        <div class="context-menu-item">Open With &gt;</div>
+                    </ActivatorContent>
+                    <ChildContent>
+                        @foreach (var app in _openWith)
+                        {
+                            <MudMenuItem OnClick="() => OpenWith(app.Command)">@app.Name</MudMenuItem>
+                        }
+                    </ChildContent>
+                </MudMenu>
                 <div class="context-menu-item" @onclick='() => ContextAction("rename")'>Rename</div>
                 <div class="context-menu-item" @onclick='() => ContextAction("delete")'>Delete</div>
                 <div class="context-menu-separator"></div>

--- a/wasm/HackerSimulator.Wasm/App/FileExplorerApp.razor.cs
+++ b/wasm/HackerSimulator.Wasm/App/FileExplorerApp.razor.cs
@@ -18,6 +18,7 @@ namespace HackerSimulator.Wasm.Apps
         [Inject] private FileSystemService FS { get; set; } = default!;
         [Inject] private FileTypeService FileTypes { get; set; } = default!;
 
+        [Inject] private ApplicationService Apps { get; set; } = default!;
         private string _path = "/home/user";
         private List<FileSystemService.FileSystemEntry> _entries = new();
         private HashSet<string> Selected { get; } = new();
@@ -26,6 +27,7 @@ namespace HackerSimulator.Wasm.Apps
         private (bool cut, List<string> paths)? _clipboard;
         private readonly Dictionary<string, ShortcutData> _shortcuts = new();
 
+        private List<ApplicationService.AppInfo> _openWith = new();
         private bool ShowHidden { get; set; }
         private FileListViewMode ViewMode { get; set; } = FileListViewMode.List;
 
@@ -248,6 +250,7 @@ namespace HackerSimulator.Wasm.Apps
         private void ShowContextMenu(MouseEventArgs e, FileSystemService.FileSystemEntry? entry)
         {
             _menuEntry = entry;
+            _openWith = entry == null ? new List<ApplicationService.AppInfo>() : Apps.GetAppsForFile(EntryPath(entry)).ToList();
             _menuX = e.ClientX;
             _menuY = e.ClientY;
             _showMenu = true;
@@ -294,6 +297,13 @@ namespace HackerSimulator.Wasm.Apps
             _showMenu = false;
         }
 
+        private async Task OpenWith(string command)
+        {
+            if (_menuEntry == null) return;
+            var path = EntryPath(_menuEntry);
+            await Shell.Run(command, new[] { path }, this);
+            _showMenu = false;
+        }
         private record ShortcutData(string Command, string[]? Args, string? Icon);
     }
 }

--- a/wasm/HackerSimulator.Wasm/Core/ApplicationService.cs
+++ b/wasm/HackerSimulator.Wasm/Core/ApplicationService.cs
@@ -14,6 +14,7 @@ namespace HackerSimulator.Wasm.Core
         public record AppInfo(string Command, string Name, string Icon);
 
         private readonly List<AppInfo> _apps = new();
+        private readonly Dictionary<string, string[]> _openExtensions = new();
 
         public ApplicationService()
         {
@@ -31,6 +32,13 @@ namespace HackerSimulator.Wasm.Core
                 var cmd = type.Name.ToLowerInvariant();
                 var name = ToDisplayName(type.Name);
                 var iconAttr = type.GetCustomAttribute<AppIconAttribute>();
+                var exts = type.GetCustomAttributes(typeof(OpenFileTypeAttribute), false)
+                    .Cast<OpenFileTypeAttribute>()
+                    .SelectMany(a => a.Extensions)
+                    .Select(e => e.ToLowerInvariant())
+                    .ToArray();
+                if (exts.Length > 0)
+                    _openExtensions[cmd] = exts;
                 var icon = iconAttr?.Icon ?? "fa:window-maximize";
 
                 _apps.Add(new AppInfo(cmd, name, icon));
@@ -50,5 +58,15 @@ namespace HackerSimulator.Wasm.Core
         public IReadOnlyList<AppInfo> GetApps() => _apps;
 
         public AppInfo? GetApp(string command) => _apps.FirstOrDefault(a => a.Command == command);
+        public IEnumerable<AppInfo> GetAppsForFile(string filename)
+        {
+            var ext = System.IO.Path.GetExtension(filename)?.TrimStart('.').ToLowerInvariant();
+            if (string.IsNullOrEmpty(ext))
+                return Array.Empty<AppInfo>();
+            return _openExtensions
+                .Where(kv => kv.Value.Any(e => e == ext))
+                .Select(kv => _apps.First(a => a.Command == kv.Key))
+                .ToList();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- expand `ApplicationService` to track file associations and expose `GetAppsForFile`
- inject `ApplicationService` in `FileExplorerApp`
- add "Open With" submenu using MudBlazor in file explorer context menu

## Testing
- `dotnet build HackerSimulator.Wasm`