### PR TITLE
Add upload/download and zip features to WASM

### DIFF
--- a/wasm/HackerSimulator.Wasm/App/FileExplorerApp.razor
+++ b/wasm/HackerSimulator.Wasm/App/FileExplorerApp.razor
@@ -18,8 +18,11 @@
             <button class="view-btn @(ViewMode == FileListViewMode.Grid ? "active" : null)" @onclick="() => SetView(FileListViewMode.Grid)">Grid</button>
             <button class="view-btn @(ViewMode == FileListViewMode.List ? "active" : null)" @onclick="() => SetView(FileListViewMode.List)">List</button>
             <button class="view-btn show-hidden @(ShowHidden ? "active" : null)" @onclick="ToggleHidden">Hidden</button>
+            <button class="view-btn upload-btn" @onclick="TriggerUpload">Upload</button>
+            <button class="view-btn download-btn" @onclick="DownloadSelection">Download</button>
         </div>
     </div>
+    <InputFile id="@_fileInputId" OnChange="HandleFileSelected" multiple style="display:none" @ref="_fileInput" />
     <div class="file-explorer-main">
         <div class="file-explorer-sidebar">
             <div class="sidebar-section">

--- a/wasm/HackerSimulator.Wasm/App/FileExplorerApp.razor.cs
+++ b/wasm/HackerSimulator.Wasm/App/FileExplorerApp.razor.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 using System.Text.Json;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.JSInterop;
 using HackerSimulator.Wasm.Dialogs;
 using HackerSimulator.Wasm.Core;
 using HackerSimulator.Wasm.Core;
@@ -17,6 +19,8 @@ namespace HackerSimulator.Wasm.Apps
     {
         [Inject] private FileSystemService FS { get; set; } = default!;
         [Inject] private FileTypeService FileTypes { get; set; } = default!;
+        [Inject] private FileOpsService FileOps { get; set; } = default!;
+        [Inject] private IJSRuntime JS { get; set; } = default!;
 
         private string _path = "/home/user";
         private List<FileSystemService.FileSystemEntry> _entries = new();
@@ -25,6 +29,8 @@ namespace HackerSimulator.Wasm.Apps
         private int _historyIndex = -1;
         private (bool cut, List<string> paths)? _clipboard;
         private readonly Dictionary<string, ShortcutData> _shortcuts = new();
+        private InputFile? _fileInput;
+        private readonly string _fileInputId = "fileInput" + Guid.NewGuid().ToString("N");
 
         private bool ShowHidden { get; set; }
         private FileListViewMode ViewMode { get; set; } = FileListViewMode.List;
@@ -292,6 +298,52 @@ namespace HackerSimulator.Wasm.Apps
                     break;
             }
             _showMenu = false;
+        }
+
+        private async Task TriggerUpload()
+        {
+            await JS.InvokeVoidAsync("eval", $"document.getElementById('{_fileInputId}').click()");
+        }
+
+        private async Task HandleFileSelected(InputFileChangeEventArgs e)
+        {
+            foreach (var file in e.GetMultipleFiles())
+            {
+                using var stream = file.OpenReadStream(long.MaxValue);
+                using var ms = new System.IO.MemoryStream();
+                await stream.CopyToAsync(ms);
+                var bytes = ms.ToArray();
+                var path = (_path == "/" ? string.Empty : _path) + "/" + file.Name;
+                await FS.WriteBinaryFile(path, bytes);
+            }
+            await Load();
+        }
+
+        private async Task DownloadSelection()
+        {
+            if (Selected.Count == 0) return;
+            if (Selected.Count == 1)
+            {
+                var path = Selected.First();
+                var stat = await FS.Stat(path);
+                if (stat.IsDirectory)
+                {
+                    var bytes = await FS.ZipEntry(path);
+                    var name = path.Split('/').Last() + ".zip";
+                    await FileOps.SaveFile(name, bytes);
+                }
+                else
+                {
+                    var bytes = await FS.ReadFileBytes(path);
+                    var name = path.Split('/').Last();
+                    await FileOps.SaveFile(name, bytes);
+                }
+            }
+            else
+            {
+                var bytes = await FS.ZipEntries(Selected);
+                await FileOps.SaveFile("download.zip", bytes);
+            }
         }
 
         private record ShortcutData(string Command, string[]? Args, string? Icon);

--- a/wasm/HackerSimulator.Wasm/Commands/linux/ZipCommand.cs
+++ b/wasm/HackerSimulator.Wasm/Commands/linux/ZipCommand.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Commands.Linux
+{
+    public class ZipCommand : CommandBase
+    {
+        private readonly FileSystemService _fs;
+        public ZipCommand(ShellService shell, KernelService kernel, FileSystemService fs)
+            : base("zip", shell, kernel)
+        {
+            _fs = fs;
+        }
+
+        public override string Description => "Create zip archive";
+        public override string Usage => "zip SOURCE [DEST]";
+
+        protected override async Task ExecuteInternal(string[] args, CommandContext context)
+        {
+            if (args.Length == 0)
+            {
+                context.Stderr.WriteLine($"Usage: {Usage}");
+                return;
+            }
+
+            var cwd = context.Env.TryGetValue("PWD", out var c) ? c : "/";
+            var source = _fs.ResolvePath(args[0], cwd);
+            var dest = args.Length > 1 ? _fs.ResolvePath(args[1], cwd) : null;
+
+            try
+            {
+                var bytes = await _fs.ZipEntry(source);
+                if (dest != null)
+                {
+                    await _fs.WriteBinaryFile(dest, bytes);
+                }
+                else
+                {
+                    var b64 = Convert.ToBase64String(bytes);
+                    context.Stdout.WriteLine(b64);
+                }
+            }
+            catch (Exception ex)
+            {
+                context.Stderr.WriteLine($"zip: {ex.Message}");
+            }
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Core/FileOpsService.cs
+++ b/wasm/HackerSimulator.Wasm/Core/FileOpsService.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.JSInterop;
+
+namespace HackerSimulator.Wasm.Core
+{
+    public class FileOpsService : IAsyncDisposable
+    {
+        private readonly IJSRuntime _js;
+        private IJSObjectReference? _module;
+
+        public FileOpsService(IJSRuntime js)
+        {
+            _js = js;
+        }
+
+        private async Task<IJSObjectReference> GetModule()
+        {
+            if (_module == null)
+            {
+                _module = await _js.InvokeAsync<IJSObjectReference>("import", "./js/fileops.js");
+            }
+            return _module;
+        }
+
+        public async Task SaveFile(string name, byte[] bytes)
+        {
+            var mod = await GetModule();
+            await mod.InvokeVoidAsync("saveFile", name, bytes);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_module != null)
+            {
+                await _module.DisposeAsync();
+            }
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Program.cs
+++ b/wasm/HackerSimulator.Wasm/Program.cs
@@ -22,6 +22,7 @@ namespace HackerSimulator.Wasm
             builder.Services.AddSingleton<DatabaseService>();
             builder.Services.AddSingleton<FileSystemService>();
             builder.Services.AddSingleton<FileTypeService>();
+            builder.Services.AddSingleton<FileOpsService>();
 
             // Register application discovery service
             builder.Services.AddSingleton<ApplicationService>();

--- a/wasm/HackerSimulator.Wasm/wwwroot/js/fileops.js
+++ b/wasm/HackerSimulator.Wasm/wwwroot/js/fileops.js
@@ -1,0 +1,13 @@
+export function saveFile(name, bytes) {
+  const blob = new Blob([new Uint8Array(bytes)], { type: 'application/octet-stream' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = name;
+  document.body.appendChild(a);
+  a.click();
+  setTimeout(() => {
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }, 0);
+}


### PR DESCRIPTION
## Summary
- add JS module to download files in the browser
- create FileOpsService for download via JS interop
- extend FileSystemService with methods to read bytes and create zip archives
- expose a new `zip` terminal command
- enable upload/download UI in the WASM file explorer
- register FileOpsService in the application startup

## Testing
- `dotnet build wasm/HackerSimulator.Wasm/HackerSimulator.Wasm.csproj -clp:ErrorsOnly`
- `npm run build:debug` *(fails: webpack not found)*