### PR TITLE
Add HackPaint app skeleton

### DIFF
--- a/wasm/HackerSimulator.Wasm/App/HackPaintApp.razor
+++ b/wasm/HackerSimulator.Wasm/App/HackPaintApp.razor
@@ -1,0 +1,25 @@
+@namespace HackerSimulator.Wasm.Apps
+@inherits HackerSimulator.Wasm.Windows.WindowBase
+
+<div class="hack-paint-toolbar">
+    <button @onclick="NewDocument">New</button>
+    <InputFile OnChange="LoadImage" />
+    <button @onclick="ExportImage">Export</button>
+    <button @onclick="Undo">Undo</button>
+    <button @onclick="Redo">Redo</button>
+    <button @onclick="Rotate90">Rotate 90°</button>
+    <button @onclick="ToggleGrid">Grid</button>
+    <button @onclick="ZoomIn">Zoom In</button>
+    <button @onclick="ZoomOut">Zoom Out</button>
+    <select @bind="_exportFormat">
+        <option value="png">PNG</option>
+        <option value="jpeg">JPEG</option>
+    </select>
+    <input type="range" min="0" max="1" step="0.1" @bind="_quality" />
+    <input type="color" @bind="_color" />
+    <input type="range" min="1" max="50" @bind="_size" />
+</div>
+<div class="hack-paint-canvas-container @( _showGrid ? "grid" : string.Empty )" id="@ContainerId" @ref="containerRef">
+    <canvas class="hack-paint-canvas" id="@CanvasId" width="@_width" height="@_height"
+            @onmousedown="HandleMouseDown" @onmousemove="HandleMouseMove" @onmouseup="HandleMouseUp" @onmouseleave="HandleMouseUp"></canvas>
+</div>

--- a/wasm/HackerSimulator.Wasm/App/HackPaintApp.razor.cs
+++ b/wasm/HackerSimulator.Wasm/App/HackPaintApp.razor.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Apps
+{
+    [AppIcon("fa:paint-brush")]
+    public partial class HackPaintApp : Windows.WindowBase, IAsyncDisposable
+    {
+        [Inject] private IJSRuntime JS { get; set; } = default!;
+
+        private IJSObjectReference? _module;
+        private ElementReference containerRef;
+        private double _width = 800;
+        private double _height = 600;
+        private double _scale = 1;
+        private bool _showGrid;
+        private string _exportFormat = "png";
+        private double _quality = 0.92;
+        private string _color = "#000000";
+        private double _size = 5;
+        private bool _drawing;
+        private readonly List<string> _history = new();
+        private int _historyIndex = -1;
+        private string CanvasId { get; } = "canvas" + Guid.NewGuid().ToString("N");
+        private string ContainerId { get; } = "container" + Guid.NewGuid().ToString("N");
+
+        protected override void OnInitialized()
+        {
+            base.OnInitialized();
+            Title = "HackPaint";
+        }
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            await base.OnAfterRenderAsync(firstRender);
+            if (firstRender)
+            {
+                _module = await JS.InvokeAsync<IJSObjectReference>("import", "./js/hackpaint.js");
+                await _module.InvokeVoidAsync("init", CanvasId);
+                await PushHistory();
+            }
+        }
+
+        private async Task StartDraw(MouseEventArgs e)
+        {
+            if (_module == null) return;
+            _drawing = true;
+            await _module.InvokeVoidAsync("startDraw", CanvasId, e.OffsetX / _scale, e.OffsetY / _scale, _color, _size);
+        }
+
+        private async Task Draw(MouseEventArgs e)
+        {
+            if (_drawing && _module != null)
+                await _module.InvokeVoidAsync("draw", CanvasId, e.OffsetX / _scale, e.OffsetY / _scale);
+        }
+
+        private async Task EndDraw()
+        {
+            if (_drawing && _module != null)
+            {
+                _drawing = false;
+                await _module.InvokeVoidAsync("endDraw", CanvasId);
+                await PushHistory();
+            }
+        }
+
+        private async Task HandleMouseDown(MouseEventArgs e) => await StartDraw(e);
+        private async Task HandleMouseMove(MouseEventArgs e) => await Draw(e);
+        private async Task HandleMouseUp(MouseEventArgs e) => await EndDraw();
+
+        private async Task NewDocument()
+        {
+            if (_module == null) return;
+            var w = await JS.InvokeAsync<string?>("prompt", "Width", "800");
+            var h = await JS.InvokeAsync<string?>("prompt", "Height", "600");
+            if (int.TryParse(w, out var wi) && int.TryParse(h, out var he))
+            {
+                var color = await JS.InvokeAsync<string?>("prompt", "Background color (empty for transparent)", "#ffffff");
+                await _module.InvokeVoidAsync("clear", CanvasId, wi, he, string.IsNullOrWhiteSpace(color) ? null : color);
+                _width = wi;
+                _height = he;
+                await PushHistory();
+            }
+        }
+
+        private async Task LoadImage(InputFileChangeEventArgs e)
+        {
+            if (_module == null) return;
+            var file = e.File;
+            if (file == null) return;
+            using var stream = file.OpenReadStream(maxAllowedSize: 10 * 1024 * 1024);
+            using var ms = new MemoryStream();
+            await stream.CopyToAsync(ms);
+            var dataUrl = $"data:{file.ContentType};base64,{Convert.ToBase64String(ms.ToArray())}";
+            await _module.InvokeVoidAsync("loadImage", CanvasId, dataUrl);
+            await PushHistory();
+        }
+
+
+        private async Task ExportImage()
+        {
+            if (_module == null) return;
+            var mime = _exportFormat == "jpeg" ? "image/jpeg" : "image/png";
+            var url = await _module.InvokeAsync<string>("toDataUrl", CanvasId, mime, _quality);
+            await _module.InvokeVoidAsync("download", url, $"image.{_exportFormat}");
+        }
+
+        private async Task Rotate90()
+        {
+            if (_module == null) return;
+            await _module.InvokeVoidAsync("rotate90", CanvasId);
+            await PushHistory();
+        }
+
+        private async Task ToggleGrid()
+        {
+            if (_module == null) return;
+            _showGrid = !_showGrid;
+            await _module.InvokeVoidAsync("toggleGrid", ContainerId);
+        }
+
+        private async Task ZoomIn()
+        {
+            if (_module == null) return;
+            _scale *= 1.25;
+            await _module.InvokeVoidAsync("setScale", CanvasId, _scale);
+        }
+
+        private async Task ZoomOut()
+        {
+            if (_module == null) return;
+            _scale *= 0.8;
+            await _module.InvokeVoidAsync("setScale", CanvasId, _scale);
+        }
+
+        private async Task PushHistory()
+        {
+            if (_module == null) return;
+            var url = await _module.InvokeAsync<string>("toDataUrl", CanvasId, "image/png", 1.0);
+            if (_historyIndex < _history.Count - 1)
+                _history.RemoveRange(_historyIndex + 1, _history.Count - _historyIndex - 1);
+            _history.Add(url);
+            _historyIndex = _history.Count - 1;
+        }
+
+        private async Task Undo()
+        {
+            if (_module == null) return;
+            if (_historyIndex > 0)
+            {
+                _historyIndex--;
+                await _module.InvokeVoidAsync("loadImage", CanvasId, _history[_historyIndex]);
+            }
+        }
+
+        private async Task Redo()
+        {
+            if (_module == null) return;
+            if (_historyIndex < _history.Count - 1)
+            {
+                _historyIndex++;
+                await _module.InvokeVoidAsync("loadImage", CanvasId, _history[_historyIndex]);
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_module != null)
+                await _module.DisposeAsync();
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/App/HackPaintApp.razor.css
+++ b/wasm/HackerSimulator.Wasm/App/HackPaintApp.razor.css
@@ -1,0 +1,40 @@
+.hack-paint-toolbar {
+    display:flex;
+    gap:5px;
+    padding:5px;
+    background:#333;
+}
+.hack-paint-toolbar button {
+    background:#555;
+    color:#fff;
+    border:none;
+    padding:4px 8px;
+    cursor:pointer;
+}
+.hack-paint-toolbar input[type="color"],
+.hack-paint-toolbar input[type="range"] {
+    margin-left:5px;
+}
+.hack-paint-canvas-container {
+    width:100%;
+    height:100%;
+    overflow:auto;
+    background:#222;
+    position:relative;
+}
+.hack-paint-canvas-container.grid {
+    background-image:
+        linear-gradient(0deg, transparent 24%, rgba(255,255,255,0.1) 25%, rgba(255,255,255,0.1) 26%, transparent 27%, transparent 74%, rgba(255,255,255,0.1) 75%, rgba(255,255,255,0.1) 76%, transparent 77%),
+        linear-gradient(90deg, transparent 24%, rgba(255,255,255,0.1) 25%, rgba(255,255,255,0.1) 26%, transparent 27%, transparent 74%, rgba(255,255,255,0.1) 75%, rgba(255,255,255,0.1) 76%, transparent 77%);
+    background-size:20px 20px;
+}
+.selection-rect {
+    position:absolute;
+    border:1px dashed #fff;
+    pointer-events:none;
+}
+.hack-paint-canvas {
+    background:#fff;
+    display:block;
+    margin:0 auto;
+}

--- a/wasm/HackerSimulator.Wasm/wwwroot/js/hackpaint.js
+++ b/wasm/HackerSimulator.Wasm/wwwroot/js/hackpaint.js
@@ -1,0 +1,89 @@
+export function init(id){
+    const canvas = document.getElementById(id);
+    canvas._hp_ctx = canvas.getContext('2d');
+}
+
+export function startDraw(id, x, y, color, size){
+    const ctx = document.getElementById(id)._hp_ctx;
+    ctx.beginPath();
+    ctx.strokeStyle = color;
+    ctx.lineWidth = size;
+    ctx.lineCap = 'round';
+    ctx.moveTo(x,y);
+}
+
+export function draw(id, x, y){
+    const ctx = document.getElementById(id)._hp_ctx;
+    ctx.lineTo(x,y);
+    ctx.stroke();
+}
+
+export function endDraw(id){
+    const ctx = document.getElementById(id)._hp_ctx;
+    ctx.closePath();
+}
+
+export function clear(id, width, height, color){
+    const canvas = document.getElementById(id);
+    const ctx = canvas._hp_ctx;
+    canvas.width = width;
+    canvas.height = height;
+    if(color){
+        ctx.fillStyle = color;
+        ctx.fillRect(0,0,width,height);
+    }else{
+        ctx.clearRect(0,0,width,height);
+    }
+}
+
+export function loadImage(id, dataUrl){
+    return new Promise((resolve, reject)=>{
+        const img = new Image();
+        img.onload = () => {
+            const canvas = document.getElementById(id);
+            canvas.width = img.width;
+            canvas.height = img.height;
+            const ctx = canvas._hp_ctx;
+            ctx.drawImage(img,0,0);
+            resolve();
+        };
+        img.onerror = reject;
+        img.src = dataUrl;
+    });
+}
+
+export function rotate90(id){
+    const canvas = document.getElementById(id);
+    const temp = document.createElement('canvas');
+    temp.width = canvas.width;
+    temp.height = canvas.height;
+    const tctx = temp.getContext('2d');
+    tctx.drawImage(canvas,0,0);
+    canvas.width = temp.height;
+    canvas.height = temp.width;
+    const ctx = canvas._hp_ctx;
+    ctx.save();
+    ctx.translate(canvas.width,0);
+    ctx.rotate(Math.PI/2);
+    ctx.drawImage(temp,0,0);
+    ctx.restore();
+}
+
+export function toDataUrl(id, mime, quality){
+    return document.getElementById(id).toDataURL(mime, quality);
+}
+
+export function setScale(id, scale){
+    document.getElementById(id).style.transform = `scale(${scale})`;
+}
+
+export function toggleGrid(id){
+    document.getElementById(id).classList.toggle('grid');
+}
+
+export function download(dataUrl, name){
+    const a = document.createElement('a');
+    a.href = dataUrl;
+    a.download = name;
+    a.click();
+}


### PR DESCRIPTION
## Summary
- add a simple HackPaint drawing app for the Blazor WebAssembly version
- implement drawing and basic tools with JavaScript helpers
- include minimal toolbar and canvas interactions

## Testing
- `dotnet build wasm/HackerSimulator.Wasm/HackerSimulator.Wasm.csproj -clp:ErrorsOnly`