### PR TITLE
Add save and rotate features to HackPaint

### DIFF
--- a/wasm/HackerSimulator.Wasm/App/HackPaintApp.razor
+++ b/wasm/HackerSimulator.Wasm/App/HackPaintApp.razor
@@ -2,12 +2,16 @@
 @inherits HackerSimulator.Wasm.Windows.WindowBase
 
 <div class="hack-paint-toolbar">
+    <input type="text" @bind="_path" placeholder="/path/file.hpaint" class="path-box" />
+    <button @onclick="OpenFile">Open</button>
+    <button @onclick="SaveFile">Save</button>
     <button @onclick="NewDocument">New</button>
     <InputFile OnChange="LoadImage" />
     <button @onclick="ExportImage">Export</button>
     <button @onclick="Undo">Undo</button>
     <button @onclick="Redo">Redo</button>
     <button @onclick="Rotate90">Rotate 90°</button>
+    <button @onclick="Rotate">Rotate</button>
     <button @onclick="ToggleGrid">Grid</button>
     <button @onclick="ZoomIn">Zoom In</button>
     <button @onclick="ZoomOut">Zoom Out</button>

--- a/wasm/HackerSimulator.Wasm/wwwroot/js/hackpaint.js
+++ b/wasm/HackerSimulator.Wasm/wwwroot/js/hackpaint.js
@@ -69,6 +69,28 @@ export function rotate90(id){
     ctx.restore();
 }
 
+export function rotate(id, angle){
+    const rad = angle * Math.PI / 180.0;
+    const canvas = document.getElementById(id);
+    const temp = document.createElement('canvas');
+    temp.width = canvas.width;
+    temp.height = canvas.height;
+    const tctx = temp.getContext('2d');
+    tctx.drawImage(canvas,0,0);
+    const cos = Math.abs(Math.cos(rad));
+    const sin = Math.abs(Math.sin(rad));
+    const newWidth = Math.round(temp.width * cos + temp.height * sin);
+    const newHeight = Math.round(temp.width * sin + temp.height * cos);
+    canvas.width = newWidth;
+    canvas.height = newHeight;
+    const ctx = canvas._hp_ctx;
+    ctx.save();
+    ctx.translate(newWidth / 2, newHeight / 2);
+    ctx.rotate(rad);
+    ctx.drawImage(temp, -temp.width / 2, -temp.height / 2);
+    ctx.restore();
+}
+
 export function toDataUrl(id, mime, quality){
     return document.getElementById(id).toDataURL(mime, quality);
 }


### PR DESCRIPTION
## Summary
- implement open/save UI for HackPaint
- support rotation by arbitrary angle
- add open/save handlers and new OpenFileType attribute
- add JS helper for arbitrary rotation

## Testing
- `dotnet build HackerSimulator.Wasm.sln`