### PR TITLE
Add basic MudBlazor System Monitor

### DIFF
--- a/wasm/HackerSimulator.Wasm/App/SystemMonitorApp.razor
+++ b/wasm/HackerSimulator.Wasm/App/SystemMonitorApp.razor
@@ -1,9 +1,58 @@
 @namespace HackerSimulator.Wasm.Apps
 @inherits HackerSimulator.Wasm.Windows.WindowBase
 
+@using MudBlazor
+
 <div class="system-monitor">
-    <div>CPU: @_cpuUsage% </div>
-    <div class="bar"><div class="fill" style="width:@_cpuUsage%"></div></div>
-    <div>Memory: @_memUsage% </div>
-    <div class="bar"><div class="fill" style="width:@_memUsage%"></div></div>
+    <MudTabs>
+        <MudTabPanel Text="Overview">
+            <div class="overview-cards">
+                <MudPaper Class="resource-card">
+                    <div class="card-header">CPU Usage</div>
+                    <MudProgressLinear Color="Color.Primary" Value="@_cpuUsage" />
+                    <div class="resource-value">@($"{_cpuUsage:F1}%")</div>
+                </MudPaper>
+                <MudPaper Class="resource-card">
+                    <div class="card-header">Memory Usage</div>
+                    <MudProgressLinear Color="Color.Secondary" Value="@_memUsage" />
+                    <div class="resource-value">@($"{_memUsage:F1}%")</div>
+                </MudPaper>
+                <MudPaper Class="resource-card">
+                    <div class="card-header">Disk Usage</div>
+                    <MudProgressLinear Color="Color.Info" Value="@_diskUsage" />
+                    <div class="resource-value">@($"{_diskUsage:F1}%")</div>
+                </MudPaper>
+                <MudPaper Class="resource-card">
+                    <div class="card-header">Network</div>
+                    <MudProgressLinear Color="Color.Success" Value="@_networkUsage" />
+                    <div class="resource-value">@($"{_networkUsage:F1}%")</div>
+                </MudPaper>
+            </div>
+        </MudTabPanel>
+        <MudTabPanel Text="Processes">
+            <MudTable Items="@_processList" Dense="true" Hover="true">
+                <HeaderContent>
+                    <MudTh>PID</MudTh>
+                    <MudTh>Name</MudTh>
+                    <MudTh>State</MudTh>
+                    <MudTh Align="Right">CPU %</MudTh>
+                    <MudTh Align="Right">Mem %</MudTh>
+                    <MudTh></MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd>@context.Pid</MudTd>
+                    <MudTd>@context.Name</MudTd>
+                    <MudTd>@context.State</MudTd>
+                    <MudTd Align="Right">@context.Cpu.ToString("0.0")</MudTd>
+                    <MudTd Align="Right">@context.Memory.ToString("0.0")</MudTd>
+                    <MudTd>
+                        <MudIconButton Icon="@Icons.Material.Filled.Close" Color="Color.Error" OnClick="() => EndProcess(context.Id)" />
+                    </MudTd>
+                </RowTemplate>
+            </MudTable>
+        </MudTabPanel>
+        <MudTabPanel Text="Performance">
+            <MudChart ChartType="ChartType.Line" Labels="@_chartLabels" Datasets="@_chartData" Style="height:250px" />
+        </MudTabPanel>
+    </MudTabs>
 </div>

--- a/wasm/HackerSimulator.Wasm/App/SystemMonitorApp.razor.cs
+++ b/wasm/HackerSimulator.Wasm/App/SystemMonitorApp.razor.cs
@@ -1,35 +1,132 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using HackerSimulator.Wasm.Core;
+using MudBlazor;
 
 namespace HackerSimulator.Wasm.Apps
 {
     [AppIcon("fa:chart-line")]
     public partial class SystemMonitorApp : Windows.WindowBase, IDisposable
     {
+
         private Timer? _timer;
-        private int _cpuUsage;
-        private int _memUsage;
+        private readonly Dictionary<Guid, ProcessMetrics> _metrics = new();
+        private readonly List<double> _cpuHistory = new();
+        private readonly List<double> _memHistory = new();
+        private const int MaxHistory = 30;
+        private readonly Random _rand = new();
+
+        private double _cpuUsage;
+        private double _memUsage;
+        private double _diskUsage;
+        private double _networkUsage;
+
+        private List<ProcessItem> _processList = new();
 
         protected override void OnInitialized()
         {
             base.OnInitialized();
             Title = "System Monitor";
-            _timer = new Timer(UpdateUsage, null, 0, 2000);
+            _timer = new Timer(Update, null, 0, 1000);
         }
 
-        private void UpdateUsage(object? state)
+        private void Update(object? state)
         {
-            var rnd = new Random();
-            _cpuUsage = rnd.Next(0, 100);
-            _memUsage = rnd.Next(0, 100);
+            var processes = Kernel.Processes;
+
+            foreach (var p in processes)
+            {
+                if (!_metrics.TryGetValue(p.Process.Id, out var m))
+                {
+                    m = new ProcessMetrics(p.Process.Id, p.Process.Name)
+                    {
+                        Cpu = _rand.NextDouble() * 10,
+                        Memory = _rand.NextDouble() * 10,
+                        State = p.Process.State.ToString()
+                    };
+                    _metrics[p.Process.Id] = m;
+                }
+                else
+                {
+                    m.Cpu = Clamp(m.Cpu + (_rand.NextDouble() - 0.5) * 5, 0, 50);
+                    m.Memory = Clamp(m.Memory + (_rand.NextDouble() - 0.5) * 2, 0, 50);
+                    m.State = p.Process.State.ToString();
+                }
+            }
+
+            var ids = processes.Select(p => p.Process.Id).ToHashSet();
+            foreach (var id in _metrics.Keys.Where(k => !ids.Contains(k)).ToList())
+                _metrics.Remove(id);
+
+            _cpuUsage = _metrics.Values.Sum(x => x.Cpu);
+            if (_cpuUsage > 100) _cpuUsage = 100;
+            _memUsage = _metrics.Values.Sum(x => x.Memory);
+            if (_memUsage > 100) _memUsage = 100;
+
+            _diskUsage = Clamp(_diskUsage + (_rand.NextDouble() - 0.5) * 5, 0, 100);
+            _networkUsage = Clamp(_networkUsage + (_rand.NextDouble() - 0.5) * 5, 0, 100);
+
+            _cpuHistory.Add(_cpuUsage);
+            _memHistory.Add(_memUsage);
+            if (_cpuHistory.Count > MaxHistory)
+            {
+                _cpuHistory.RemoveAt(0);
+                _memHistory.RemoveAt(0);
+            }
+
+            _processList = _metrics.Values.Select(m => new ProcessItem
+            {
+                Id = m.Id,
+                Name = m.Name,
+                State = m.State,
+                Cpu = m.Cpu,
+                Memory = m.Memory
+            }).ToList();
+
             InvokeAsync(StateHasChanged);
         }
 
-        public void Dispose()
+        private static double Clamp(double val, double min, double max)
+            => val < min ? min : val > max ? max : val;
+
+        private void EndProcess(Guid id)
+        {
+            Kernel.KillProcess(id);
+        }
+
+        private string[] _chartLabels => Enumerable.Range(0, _cpuHistory.Count)
+            .Select(i => i.ToString())
+            .ToArray();
+
+        private ChartSeries[] _chartData => new[]
+        {
+            new ChartSeries { Name = "CPU", Data = _cpuHistory.ToArray() },
+            new ChartSeries { Name = "Memory", Data = _memHistory.ToArray() }
+        };
+
+        public new void Dispose()
         {
             _timer?.Dispose();
+            base.Dispose();
+        }
+
+        private record ProcessMetrics(Guid Id, string Name)
+        {
+            public double Cpu { get; set; }
+            public double Memory { get; set; }
+            public string State { get; set; } = string.Empty;
+        }
+
+        private class ProcessItem
+        {
+            public Guid Id { get; set; }
+            public string Pid => Id.ToString()[..8];
+            public string Name { get; set; } = string.Empty;
+            public string State { get; set; } = string.Empty;
+            public double Cpu { get; set; }
+            public double Memory { get; set; }
         }
     }
 }

--- a/wasm/HackerSimulator.Wasm/App/SystemMonitorApp.razor.css
+++ b/wasm/HackerSimulator.Wasm/App/SystemMonitorApp.razor.css
@@ -1,0 +1,17 @@
+.system-monitor {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    padding: 10px;
+    box-sizing: border-box;
+}
+.overview-cards {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    margin-bottom:16px;
+}
+.resource-card {
+    width: 200px;
+    padding: 8px;
+}


### PR DESCRIPTION
## Summary
- implement new MudBlazor-based SystemMonitor app for WASM project
- show overview cards, processes table and performance chart
- simulate cpu/memory/disk/network usage and update periodically
- add styles for the new app

## Testing
- `dotnet build wasm/HackerSimulator.Wasm/HackerSimulator.Wasm.csproj -clp:ErrorsOnly`