### PR TITLE
Add zip folder menu and view zip contents

### DIFF
--- a/wasm/HackerSimulator.Wasm/App/FileExplorerApp.razor
+++ b/wasm/HackerSimulator.Wasm/App/FileExplorerApp.razor
@@ -71,6 +71,11 @@
                 <div class="context-menu-item" @onclick='() => ContextAction("rename")'>Rename</div>
                 <div class="context-menu-item" @onclick='() => ContextAction("delete")'>Delete</div>
                 <div class="context-menu-separator"></div>
+                @if (_menuEntry.IsDirectory)
+                {
+                    <div class="context-menu-item" @onclick='() => ContextAction("zip-folder")'>Zip Directory</div>
+                    <div class="context-menu-separator"></div>
+                }
                 <div class="context-menu-item" @onclick='() => ContextAction("copy")'>Copy</div>
                 <div class="context-menu-item" @onclick='() => ContextAction("cut")'>Cut</div>
             }


### PR DESCRIPTION
## Summary
- allow compressing directories with new **Zip Directory** context menu item
- enable exploring zip archives inside File Explorer
- mark FileExplorerApp as default app for `.zip` files

## Testing
- `dotnet build wasm/HackerSimulator.Wasm/HackerSimulator.Wasm.csproj -clp:ErrorsOnly`