### PR TITLE
Add Wasm GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy-wasm.yml
+++ b/.github/workflows/deploy-wasm.yml
@@ -1,0 +1,52 @@
+name: Deploy Wasm App to GitHub Pages
+
+on:
+  push:
+    branches: [ "Wasm" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages-wasm"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "9.0.x"
+
+      - name: Install wasm workload
+        run: dotnet workload install wasm-tools
+
+      - name: Publish
+        run: dotnet publish ./wasm/HackerSimulator.Wasm.sln -c Release -o publish
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./publish/wwwroot
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- add GitHub action to deploy Wasm build to GitHub Pages

## Testing
- `dotnet publish wasm/HackerSimulator.Wasm.sln -c Release -o /tmp/wasm_publish`
