### PR TITLE
Add Settings service and GUI

### DIFF
--- a/wasm/HackerSimulator.Wasm/App/SettingEditor.razor
+++ b/wasm/HackerSimulator.Wasm/App/SettingEditor.razor
@@ -1,0 +1,43 @@
+@namespace HackerSimulator.Wasm.Apps
+@using MudBlazor
+
+<div class="setting-editor">
+<MudTable Items="Items" Dense="true" Hover="true">
+    <HeaderContent>
+        <MudTh>Key</MudTh>
+        <MudTh>Value</MudTh>
+        <MudTh></MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd><MudTextField @bind-Value="context.Key" Immediate="true" /></MudTd>
+        <MudTd><MudTextField @bind-Value="context.Value" Immediate="true" /></MudTd>
+        <MudTd>
+            <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small" OnClick="() => Remove(context)" />
+        </MudTd>
+    </RowTemplate>
+</MudTable>
+<MudButton Variant="Variant.Outlined" Color="Color.Secondary" StartIcon="@Icons.Material.Filled.Add" OnClick="Add">Add</MudButton>
+</div>
+
+@code {
+    [Parameter] public List<SettingItem> Items { get; set; } = new();
+    [Parameter] public EventCallback Changed { get; set; }
+
+    private void Add()
+    {
+        Items.Add(new SettingItem());
+        Changed.InvokeAsync();
+    }
+
+    private void Remove(SettingItem kv)
+    {
+        Items.Remove(kv);
+        Changed.InvokeAsync();
+    }
+
+    public class SettingItem
+    {
+        public string Key { get; set; } = string.Empty;
+        public string Value { get; set; } = string.Empty;
+    }
+}

--- a/wasm/HackerSimulator.Wasm/App/SettingEditor.razor.css
+++ b/wasm/HackerSimulator.Wasm/App/SettingEditor.razor.css
@@ -1,0 +1,3 @@
+.setting-editor {
+    margin-bottom:10px;
+}

--- a/wasm/HackerSimulator.Wasm/App/SettingsApp.razor
+++ b/wasm/HackerSimulator.Wasm/App/SettingsApp.razor
@@ -1,7 +1,26 @@
 @namespace HackerSimulator.Wasm.Apps
 @inherits HackerSimulator.Wasm.Windows.WindowBase
+@using MudBlazor
 
-<div class="settings">
-    <label><input type="checkbox" @bind="_dark"> Dark mode</label>
-    <button @onclick="Apply">Apply</button>
-</div>
+<MudPaper Class="settings-root">
+    <MudSelect T="string" Label="Application" Value="_selectedApp" ValueChanged="OnAppChanged" Class="app-select" Dense="true" CoerceValue="true">
+        @foreach (var app in _apps)
+        {
+            <MudSelectItem Value="@app.Command">@app.Name</MudSelectItem>
+        }
+    </MudSelect>
+
+    <MudTabs @bind-ActivePanelIndex="_tab" Class="settings-tabs">
+        <MudTabPanel Text="User">
+            <SettingEditor Items="_userSettings" Changed="_ => _dirtyUser = true" />
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="!_dirtyUser" OnClick="SaveUser">Save</MudButton>
+        </MudTabPanel>
+        <MudTabPanel Text="System" Disabled="!_isAdmin">
+            <SettingEditor Items="_machineSettings" Changed="_ => _dirtyMachine = true" />
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="!_dirtyMachine" OnClick="SaveMachine">Save</MudButton>
+        </MudTabPanel>
+    </MudTabs>
+</MudPaper>
+
+@code {
+}

--- a/wasm/HackerSimulator.Wasm/App/SettingsApp.razor.cs
+++ b/wasm/HackerSimulator.Wasm/App/SettingsApp.razor.cs
@@ -1,6 +1,8 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.JSInterop;
 using Microsoft.AspNetCore.Components;
+using MudBlazor;
 using HackerSimulator.Wasm.Core;
 
 namespace HackerSimulator.Wasm.Apps
@@ -8,19 +10,67 @@ namespace HackerSimulator.Wasm.Apps
     [AppIcon("fa:cog")]
     public partial class SettingsApp : Windows.WindowBase
     {
-        [Inject] private IJSRuntime JS { get; set; } = default!;
+        [Inject] private ApplicationService AppService { get; set; } = default!;
+        [Inject] private SettingsService Settings { get; set; } = default!;
+        [Inject] private AuthService Auth { get; set; } = default!;
 
-        private bool _dark;
+        private IReadOnlyList<ApplicationService.AppInfo> _apps = new List<ApplicationService.AppInfo>();
+        private string? _selectedApp;
+        private int _tab;
+
+        private readonly List<SettingEditor.SettingItem> _userSettings = new();
+        private readonly List<SettingEditor.SettingItem> _machineSettings = new();
+        private bool _dirtyUser;
+        private bool _dirtyMachine;
+        private bool _isAdmin;
 
         protected override void OnInitialized()
         {
             base.OnInitialized();
             Title = "Settings";
+            _apps = AppService.GetApps();
+            _isAdmin = Auth.GetUserGroup() == 1;
         }
 
-        private async Task Apply()
+        private async Task OnAppChanged(string? value)
         {
-            await JS.InvokeVoidAsync("eval", $"document.body.classList.toggle('dark',{_dark.ToString().ToLowerInvariant()})");
+            _selectedApp = value;
+            await LoadSettings();
         }
+
+        private async Task LoadSettings()
+        {
+            if (string.IsNullOrWhiteSpace(_selectedApp)) return;
+            _userSettings.Clear();
+            _machineSettings.Clear();
+            var usr = await Settings.LoadUser(_selectedApp);
+            foreach (var kv in usr)
+                _userSettings.Add(new SettingEditor.SettingItem { Key = kv.Key, Value = kv.Value });
+            var mach = await Settings.LoadMachine(_selectedApp);
+            foreach (var kv in mach)
+                _machineSettings.Add(new SettingEditor.SettingItem { Key = kv.Key, Value = kv.Value });
+            _dirtyUser = false;
+            _dirtyMachine = false;
+            StateHasChanged();
+        }
+
+        private static Dictionary<string,string> ToDictionary(IEnumerable<SettingEditor.SettingItem> items)
+            => items.Where(kv => !string.IsNullOrWhiteSpace(kv.Key))
+                .ToDictionary(kv => kv.Key, kv => kv.Value);
+
+        private async Task SaveUser()
+        {
+            if (_selectedApp == null) return;
+            await Settings.SaveUser(_selectedApp, ToDictionary(_userSettings));
+            _dirtyUser = false;
+        }
+
+        private async Task SaveMachine()
+        {
+            if (_selectedApp == null || !_isAdmin) return;
+            await Settings.SaveMachine(_selectedApp, ToDictionary(_machineSettings));
+            _dirtyMachine = false;
+        }
+
     }
 }

--- a/wasm/HackerSimulator.Wasm/App/SettingsApp.razor.css
+++ b/wasm/HackerSimulator.Wasm/App/SettingsApp.razor.css
@@ -1,0 +1,17 @@
+.settings-root {
+    padding: 10px;
+    background:#1e1e1e;
+    color:#d4d4d4;
+    height:100%;
+    display:flex;
+    flex-direction:column;
+    box-sizing:border-box;
+}
+.app-select {
+    width:200px;
+    margin-bottom:10px;
+}
+.settings-tabs {
+    flex:1;
+    overflow:auto;
+}

--- a/wasm/HackerSimulator.Wasm/Core/AutoRunService.cs
+++ b/wasm/HackerSimulator.Wasm/Core/AutoRunService.cs
@@ -30,7 +30,9 @@ namespace HackerSimulator.Wasm.Core
             _started = true;
             var fs = _services.GetRequiredService<FileSystemService>();
             await fs.InitAsync();
- var ft = _services.GetRequiredService<FileTypeService>();
+            await EnsureLinuxLayout(fs);
+
+            var ft = _services.GetRequiredService<FileTypeService>();
             ft.RegisterFromAttributes();
           
 
@@ -39,9 +41,22 @@ namespace HackerSimulator.Wasm.Core
             _auth.OnUserLogin += OnUserLogin;
         }
 
-        private void OnUserLogin(AuthService.UserRecord user)
+        private async void OnUserLogin(AuthService.UserRecord user)
         {
-            // Placeholder for tasks after user login
+            var fs = _services.GetRequiredService<FileSystemService>();
+            var path = $"/home/{user.UserName}/.config";
+            if (!await fs.Exists(path))
+                await fs.CreateDirectory(path);
+        }
+
+        private static async Task EnsureLinuxLayout(FileSystemService fs)
+        {
+            string[] dirs = ["/etc", "/usr", "/usr/bin", "/home", "/home/user", "/home/user/.config"];
+            foreach (var d in dirs)
+            {
+                if (!await fs.Exists(d))
+                    await fs.CreateDirectory(d);
+            }
         }
     }
 }

--- a/wasm/HackerSimulator.Wasm/Core/SettingsService.cs
+++ b/wasm/HackerSimulator.Wasm/Core/SettingsService.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace HackerSimulator.Wasm.Core
+{
+    /// <summary>
+    /// Provides access to per-user and machine-wide configuration files.
+    /// Settings are stored as simple key/value pairs in JSON files located
+    /// under /home/&lt;user&gt;/.config and /etc/&lt;app&gt;.
+    /// </summary>
+    public class SettingsService
+    {
+        private readonly FileSystemService _fs;
+        private readonly AuthService _auth;
+
+        public SettingsService(FileSystemService fs, AuthService auth)
+        {
+            _fs = fs;
+            _auth = auth;
+        }
+
+        private static string UserConfigPath(string user, string app)
+            => $"/home/{user}/.config/{app}.config";
+
+        private static string MachineConfigPath(string app)
+            => $"/etc/{app}/{app}.config";
+
+        private async Task EnsureDir(string path)
+        {
+            var dir = path[..path.LastIndexOf('/')];
+            if (!await _fs.Exists(dir))
+                await _fs.CreateDirectory(dir);
+        }
+
+        /// <summary>
+        /// Loads the merged settings for the specified application.
+        /// User settings override machine settings when present.
+        /// </summary>
+        public async Task<Dictionary<string, string>> Load(string app)
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var user = _auth.CurrentUser?.UserName;
+            if (user != null)
+            {
+                var userPath = UserConfigPath(user, app);
+                if (await _fs.Exists(userPath))
+                {
+                    var json = await _fs.ReadFile(userPath);
+                    var data = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
+                    if (data != null)
+                    {
+                        foreach (var kv in data)
+                            result[kv.Key] = kv.Value;
+                    }
+                }
+            }
+
+            var machinePath = MachineConfigPath(app);
+            if (await _fs.Exists(machinePath))
+            {
+                var json = await _fs.ReadFile(machinePath);
+                var data = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
+                if (data != null)
+                {
+                    foreach (var kv in data)
+                        if (!result.ContainsKey(kv.Key))
+                            result[kv.Key] = kv.Value;
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Loads the raw user settings without merging.
+        /// </summary>
+        public async Task<Dictionary<string, string>> LoadUser(string app)
+        {
+            var user = _auth.CurrentUser?.UserName ?? "user";
+            var path = UserConfigPath(user, app);
+            if (!await _fs.Exists(path)) return new();
+            var json = await _fs.ReadFile(path);
+            return JsonSerializer.Deserialize<Dictionary<string, string>>(json) ?? new();
+        }
+
+        /// <summary>
+        /// Loads the raw machine settings.
+        /// </summary>
+        public async Task<Dictionary<string, string>> LoadMachine(string app)
+        {
+            var path = MachineConfigPath(app);
+            if (!await _fs.Exists(path)) return new();
+            var json = await _fs.ReadFile(path);
+            return JsonSerializer.Deserialize<Dictionary<string, string>>(json) ?? new();
+        }
+
+        /// <summary>
+        /// Saves settings for the current user.
+        /// </summary>
+        public async Task SaveUser(string app, Dictionary<string, string> data)
+        {
+            var user = _auth.CurrentUser?.UserName ?? "user";
+            var path = UserConfigPath(user, app);
+            await EnsureDir(path);
+            var json = JsonSerializer.Serialize(data);
+            await _fs.WriteFile(path, json);
+        }
+
+        /// <summary>
+        /// Saves machine-wide settings. Only admin users are allowed.
+        /// </summary>
+        public async Task SaveMachine(string app, Dictionary<string, string> data)
+        {
+            if (_auth.GetUserGroup() != 1)
+                throw new InvalidOperationException("Only admin can modify machine settings.");
+            var path = MachineConfigPath(app);
+            await EnsureDir(path);
+            var json = JsonSerializer.Serialize(data);
+            await _fs.WriteFile(path, json);
+        }
+    }
+}

--- a/wasm/docs/settings-service.md
+++ b/wasm/docs/settings-service.md
@@ -1,0 +1,30 @@
+# Settings Service
+
+This service stores configuration for applications using the virtual file system.  
+Settings are saved in JSON files with a `.config` extension. Each application has
+machine level settings under `/etc/{app}/` and user settings under
+`/home/{user}/.config/`. User settings override machine settings.
+
+## Architecture
+- **SettingsService** – Reads and writes configuration files using
+  `FileSystemService`.
+- Automatically creates directories if they do not exist.
+- Machine settings require the user to belong to the admin group.
+
+## Usage
+```
+var settings = await Settings.Load("terminalapp");
+var userOnly = await Settings.LoadUser("terminalapp");
+await Settings.SaveUser("terminalapp", userOnly);
+```
+
+## Key Decisions
+- Linux like directory structure is enforced when the application starts.
+- `/usr/bin` is used to represent installed apps.
+- Startup service ensures `/etc`, `/usr/bin` and user config directories exist.
+
+## Task List
+- [x] Implement `SettingsService` for file-based configs.
+- [x] Ensure Linux style directories during startup.
+- [x] Create modern `SettingsApp` for editing configs.
+- [x] Document the service.


### PR DESCRIPTION
## Summary
- implement `SettingsService` for file-based per-user and system settings
- ensure Linux-like folders exist via `AutoRunService`
- add `SettingsApp` using MudBlazor with a helper `SettingEditor` component
- document the new service

## Testing
- `dotnet build wasm/HackerSimulator.Wasm/HackerSimulator.Wasm.csproj -clp:Summary`