### PR TITLE
Add WordPad editor app

### DIFF
--- a/wasm/HackerSimulator.Wasm/App/WordPadApp.razor
+++ b/wasm/HackerSimulator.Wasm/App/WordPadApp.razor
@@ -1,0 +1,17 @@
+@namespace HackerSimulator.Wasm.Apps
+@inherits HackerSimulator.Wasm.Windows.WindowBase
+
+<div class="wordpad-app">
+    <div class="toolbar">
+        <input type="text" @bind="_path" placeholder="/path/file.html" class="path-box" />
+        <button @onclick="Open">Open</button>
+        <button @onclick="Save">Save</button>
+        <button @onclick="NewDoc">New</button>
+        <button @onclick="Bold"><b>B</b></button>
+        <button @onclick="Italic"><i>I</i></button>
+        <button @onclick="Underline"><u>U</u></button>
+        <button @onclick="Bullet">• List</button>
+        <input type="color" @onchange="ChangeColor" />
+    </div>
+    <div id="@EditorId" class="editor" contenteditable="true" @ref="_editorRef"></div>
+</div>

--- a/wasm/HackerSimulator.Wasm/App/WordPadApp.razor.cs
+++ b/wasm/HackerSimulator.Wasm/App/WordPadApp.razor.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
+using HackerSimulator.Wasm.Core;
+
+namespace HackerSimulator.Wasm.Apps
+{
+    [OpenFileType("rtf", "docx", "txt", "html")]
+    [AppIcon("fa:file-word")]
+    public partial class WordPadApp : Windows.WindowBase, IAsyncDisposable
+    {
+        [Inject] private FileSystemService FS { get; set; } = default!;
+        [Inject] private IJSRuntime JS { get; set; } = default!;
+
+        private IJSObjectReference? _module;
+        private ElementReference _editorRef;
+        private string _path = string.Empty;
+        private string EditorId { get; } = "editor" + Guid.NewGuid().ToString("N");
+
+        protected override void OnInitialized()
+        {
+            base.OnInitialized();
+            Title = "WordPad";
+        }
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            await base.OnAfterRenderAsync(firstRender);
+            if (firstRender)
+            {
+                _module = await JS.InvokeAsync<IJSObjectReference>("import", "./js/wordpad.js");
+            }
+        }
+
+        private async Task ExecCmd(string cmd, string? value = null)
+        {
+            if (_module != null)
+                await _module.InvokeVoidAsync("exec", EditorId, cmd, value);
+        }
+
+        private Task Bold() => ExecCmd("bold");
+        private Task Italic() => ExecCmd("italic");
+        private Task Underline() => ExecCmd("underline");
+        private Task Bullet() => ExecCmd("insertUnorderedList");
+
+        private async Task ChangeColor(ChangeEventArgs e)
+        {
+            if (e.Value is string color)
+            {
+                await ExecCmd("foreColor", color);
+            }
+        }
+
+        private async Task Save()
+        {
+            if (_module == null || string.IsNullOrWhiteSpace(_path)) return;
+            var path = FS.ResolvePath(_path);
+            var html = await _module.InvokeAsync<string>("getHtml", EditorId);
+            await FS.WriteFile(path, html);
+        }
+
+        private async Task Open()
+        {
+            if (_module == null || string.IsNullOrWhiteSpace(_path)) return;
+            var path = FS.ResolvePath(_path);
+            if (!await FS.Exists(path)) return;
+            var html = await FS.ReadFile(path);
+            await _module.InvokeVoidAsync("setHtml", EditorId, html);
+        }
+
+        private async Task NewDoc()
+        {
+            if (_module != null)
+                await _module.InvokeVoidAsync("setHtml", EditorId, "");
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_module != null)
+                await _module.DisposeAsync();
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/App/WordPadApp.razor.css
+++ b/wasm/HackerSimulator.Wasm/App/WordPadApp.razor.css
@@ -1,0 +1,41 @@
+.wordpad-app {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.wordpad-app .toolbar {
+    background: #333;
+    padding: 4px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.wordpad-app .path-box {
+    flex: 1;
+    background: #222;
+    color: #eee;
+    border: 1px solid #555;
+    padding: 2px 4px;
+}
+
+.wordpad-app button {
+    background: #444;
+    color: #eee;
+    border: none;
+    padding: 4px 8px;
+    cursor: pointer;
+}
+
+.wordpad-app button:hover {
+    background: #555;
+}
+
+.wordpad-app .editor {
+    flex: 1;
+    background: #111;
+    color: #eee;
+    padding: 8px;
+    overflow: auto;
+}

--- a/wasm/HackerSimulator.Wasm/wwwroot/js/wordpad.js
+++ b/wasm/HackerSimulator.Wasm/wwwroot/js/wordpad.js
@@ -1,0 +1,16 @@
+export function exec(id, cmd, value){
+    const el = document.getElementById(id);
+    if(!el) return;
+    el.focus();
+    document.execCommand(cmd, false, value ?? null);
+}
+
+export function getHtml(id){
+    const el = document.getElementById(id);
+    return el ? el.innerHTML : '';
+}
+
+export function setHtml(id, html){
+    const el = document.getElementById(id);
+    if(el) el.innerHTML = html || '';
+}

--- a/wasm/docs/wordpad-app.md
+++ b/wasm/docs/wordpad-app.md
@@ -1,0 +1,32 @@
+# WordPad App
+
+This document describes the basic rich text editor application implemented for the Blazor WebAssembly version of Hacker Simulator.
+
+## Purpose
+
+WordPad provides simple word processing capabilities that sit between the plain text editor and a full office suite. Users can open, edit, and save rich text documents stored in the simulated file system.
+
+## Architecture
+
+- **WordPadApp** – Blazor window-based application using a contenteditable div for editing.
+- **wordpad.js** – JavaScript module wrapping `document.execCommand` to apply formatting and to get/set editor HTML.
+- **FileSystemService** – Used to load and save document content as HTML.
+
+## Usage
+
+- Toolbar buttons invoke formatting commands (bold, italic, underline, unordered list and text color).
+- The path box specifies the file path to open or save.
+- Files are stored as HTML text and can use extensions like `.rtf`, `.docx`, `.txt` or `.html`.
+
+## Key Decisions
+
+- Document content is stored as HTML for simplicity.
+- Formatting relies on the deprecated but widely supported `execCommand` API.
+
+## Task List
+
+- [x] Create `wordpad.js` helper module.
+- [x] Implement `WordPadApp.razor` UI.
+- [x] Implement `WordPadApp.razor.cs` logic.
+- [x] Add scoped styling in `WordPadApp.razor.css`.
+- [x] Document the feature in this file.


### PR DESCRIPTION
## Summary
- implement WordPad rich text editor window
- add JS module for formatting commands
- style WordPad with scoped CSS
- document the feature in `wasm/docs/wordpad-app.md`

## Testing
- `dotnet build wasm/HackerSimulator.Wasm/HackerSimulator.Wasm.csproj -clp:ErrorsOnly`