### PR TITLE
Add MudBlazor theme support

### DIFF
--- a/wasm/HackerSimulator.Wasm/Core/ThemeService.cs
+++ b/wasm/HackerSimulator.Wasm/Core/ThemeService.cs
@@ -1,0 +1,34 @@
+using MudBlazor;
+
+namespace HackerSimulator.Wasm.Core
+{
+    /// <summary>
+    /// Provides the MudBlazor <see cref="MudTheme"/> used throughout the application.
+    /// </summary>
+    public class ThemeService
+    {
+        /// <summary>
+        /// Gets the dark hacker style theme instance.
+        /// </summary>
+        public MudTheme CurrentTheme { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThemeService"/> class.
+        /// </summary>
+        public ThemeService()
+        {
+            CurrentTheme = new MudTheme()
+            {
+                PaletteDark = new PaletteDark
+                {
+                    Primary = Colors.Green.Accent4,
+                    Background = "#111111",
+                    Surface = "#222222",
+                    TextPrimary = "#ffffff",
+                    AppbarBackground = "#1b1b1b",
+                    DrawerBackground = "#1b1b1b",
+                }
+            };
+        }
+    }
+}

--- a/wasm/HackerSimulator.Wasm/Program.cs
+++ b/wasm/HackerSimulator.Wasm/Program.cs
@@ -42,6 +42,7 @@ namespace HackerSimulator.Wasm
             builder.Services.AddSingleton<HomeController>();
             builder.Services.AddSingleton<Windows.WindowManagerService>();
             builder.Services.AddMudServices();
+            builder.Services.AddSingleton<ThemeService>();
 
 
             var host = builder.Build();

--- a/wasm/HackerSimulator.Wasm/Shared/MainLayout.razor
+++ b/wasm/HackerSimulator.Wasm/Shared/MainLayout.razor
@@ -2,32 +2,43 @@
 
 @inject AutoRunService AutoRun
 @inject AuthService Auth
+@inject ThemeService Theme
 @using HackerSimulator.Wasm.Pages
 
+<MudThemeProvider Theme="Theme.CurrentTheme">
+    <MudDialogProvider />
+    <MudSnackbarProvider>
+        <MudLayout>
+            <MudAppBar Elevation="0" Color="Color.Primary">
+                <MudText Typo="Typo.h6">Hacker Simulator</MudText>
+            </MudAppBar>
 
-<div class="container">
-    <NavMenu />
-    <main>
+            <MudDrawer Class="nav-drawer" Variant="DrawerVariant.Mini" Elevation="1">
+                <NavMenu />
+            </MudDrawer>
 
-        @if (!Auth.Initialized)
-        {
-            <p>Loading...</p>
-        }
-        else if (!Auth.HasUsers)
-        {
-            <Welcome />
-        }
-        else if (!Auth.IsAuthenticated)
-        {
-            <Login />
-        }
-        else
-        {
-            @Body
-        }
-    </main>
-</div>
-<Taskbar />
+            <MudMainContent>
+                @if (!Auth.Initialized)
+                {
+                    <p>Loading...</p>
+                }
+                else if (!Auth.HasUsers)
+                {
+                    <Welcome />
+                }
+                else if (!Auth.IsAuthenticated)
+                {
+                    <Login />
+                }
+                else
+                {
+                    @Body
+                }
+            </MudMainContent>
+        </MudLayout>
+        <Taskbar />
+    </MudSnackbarProvider>
+</MudThemeProvider>
 
 @code {
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/wasm/HackerSimulator.Wasm/Shared/MainLayout.razor.css
+++ b/wasm/HackerSimulator.Wasm/Shared/MainLayout.razor.css
@@ -1,9 +1,8 @@
-.container {
-    display: flex;
-    min-height: 100vh;
-    padding-bottom: 40px; /* space for taskbar */
+.nav-drawer {
+    width: 200px;
 }
-main {
-    flex: 1;
+
+.mud-main-content {
     padding: 1rem;
+    padding-bottom: 40px; /* space for taskbar */
 }

--- a/wasm/HackerSimulator.Wasm/Shared/NavMenu.razor
+++ b/wasm/HackerSimulator.Wasm/Shared/NavMenu.razor
@@ -1,14 +1,12 @@
-<nav>
-    <ul>
-        <li><NavLink href="/">Desktop</NavLink></li>
-        <li><NavLink href="terminal">Terminal</NavLink></li>
-        <li><NavLink href="file-explorer">File Explorer</NavLink></li>
-        <li><NavLink href="notepad">Notepad</NavLink></li>
-        <li><NavLink href="code-editor">Code Editor</NavLink></li>
-        <li><NavLink href="browser">Browser</NavLink></li>
-        <li><NavLink href="calculator">Calculator</NavLink></li>
-        <li><NavLink href="system-monitor">System Monitor</NavLink></li>
-        <li><NavLink href="settings">Settings</NavLink></li>
-    </ul>
-</nav>
+<MudNavMenu Class="nav-menu">
+    <MudNavLink Href="/" Match="NavLinkMatch.All">Desktop</MudNavLink>
+    <MudNavLink Href="terminal">Terminal</MudNavLink>
+    <MudNavLink Href="file-explorer">File Explorer</MudNavLink>
+    <MudNavLink Href="notepad">Notepad</MudNavLink>
+    <MudNavLink Href="code-editor">Code Editor</MudNavLink>
+    <MudNavLink Href="browser">Browser</MudNavLink>
+    <MudNavLink Href="calculator">Calculator</MudNavLink>
+    <MudNavLink Href="system-monitor">System Monitor</MudNavLink>
+    <MudNavLink Href="settings">Settings</MudNavLink>
+</MudNavMenu>
 

--- a/wasm/HackerSimulator.Wasm/Shared/NavMenu.razor.css
+++ b/wasm/HackerSimulator.Wasm/Shared/NavMenu.razor.css
@@ -1,16 +1,9 @@
-nav {
+.nav-menu {
     width: 200px;
     background-color: #202020;
     color: white;
 }
-ul {
-    list-style: none;
-    padding: 0;
-}
-li {
-    padding: 0.5rem 1rem;
-}
-li a {
-    color: inherit;
-    text-decoration: none;
+
+.nav-menu .mud-nav-link {
+    padding-left: 1rem;
 }

--- a/wasm/HackerSimulator.Wasm/wwwroot/css/app.css
+++ b/wasm/HackerSimulator.Wasm/wwwroot/css/app.css
@@ -1,0 +1,6 @@
+body {
+    margin: 0;
+    background-color: #111;
+    color: #eee;
+    font-family: 'Roboto', sans-serif;
+}

--- a/wasm/HackerSimulator.Wasm/wwwroot/index.html
+++ b/wasm/HackerSimulator.Wasm/wwwroot/index.html
@@ -11,6 +11,7 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
     <link href="https://cdn.jsdelivr.net/npm/lucide-static@0.373.0/font/Lucide.css" rel="stylesheet" />
     <link href="https://unicons.iconscout.com/release/v4.0.8/css/line.css" rel="stylesheet" />
+    <link href="css/app.css" rel="stylesheet" />
 
 </head>
 <body>


### PR DESCRIPTION
## Summary
- create `ThemeService` providing a dark hacker style `MudTheme`
- register `ThemeService` and wrap layout in MudBlazor components
- update `NavMenu` to use `MudNavMenu`/`MudNavLink`
- add global `app.css` and include it in `index.html`

## Testing
- `dotnet build wasm/HackerSimulator.Wasm.sln`