### PR TITLE
Fix DatabaseService version check

### DIFF
--- a/wasm/HackerSimulator.Wasm/wwwroot/js/database.js
+++ b/wasm/HackerSimulator.Wasm/wwwroot/js/database.js
@@ -61,6 +61,28 @@ export async function initTable(name, version){
   return current;
 }
 
+export async function ensureStore(name){
+  let d = await getDb();
+  if(!d.objectStoreNames.contains(name)){
+    const newVersion = d.version + 1;
+    d.close();
+    d = await openDb(newVersion, db => {
+      if(!db.objectStoreNames.contains(name)) db.createObjectStore(name);
+    });
+    db = d;
+  }
+}
+
+export async function getSchemaVersionFor(name){
+  const d = await getDb();
+  return await getSchemaVersion(d, name);
+}
+
+export async function setSchemaVersionFor(name, version){
+  const d = await getDb();
+  await setSchemaVersion(d, name, version);
+}
+
 export async function get(store, key){
   const d = await getDb();
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- export granular IndexedDB helpers from `database.js`
- move schema version logic from JS to C#

## Testing
- `dotnet build wasm/HackerSimulator.Wasm/HackerSimulator.Wasm.csproj`
- `dotnet test wasm/HackerSimulator.Wasm/HackerSimulator.Wasm.csproj`