### PR TITLE
Fix shell command VFS integration

### DIFF
--- a/wasm2/HackerOs/HackerOs/OS/Shell/CommandBase.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Shell/CommandBase.cs
@@ -137,9 +137,15 @@ public abstract class CommandBase : ICommand
     /// </summary>
     protected static IVirtualFileSystem GetFileSystem(CommandContext context)
     {
-        // In a real implementation, this would be injected or obtained from context
-        // For now, we'll assume it's available through the shell
-        throw new NotImplementedException("File system access needs to be implemented through dependency injection");
+        // In HackerOS the shell exposes the virtual file system via the
+        // CommandContext.  Commands can therefore access it directly without
+        // explicit dependency injection.  This helper centralises the access
+        // logic and throws a clear exception if the file system is not
+        // available.
+        if (context.FileSystem == null)
+            throw new InvalidOperationException("File system not available in command context");
+
+        return context.FileSystem;
     }
 
     /// <summary>

--- a/wasm2/HackerOs/HackerOs/OS/Shell/Commands/CatCommand.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Shell/Commands/CatCommand.cs
@@ -212,7 +212,10 @@ public class CatCommand : CommandBase
 
     private static IVirtualFileSystem GetVirtualFileSystem(CommandContext context)
     {
-        // This would be injected through DI in a real implementation
-        throw new NotImplementedException("VFS access needs proper DI integration");
+        // Access the VFS from the shell through the context
+        if (context.FileSystem == null)
+            throw new InvalidOperationException("File system not available in command context");
+
+        return context.FileSystem;
     }
 }

--- a/wasm2/HackerOs/HackerOs/OS/Shell/Commands/CdCommand.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Shell/Commands/CdCommand.cs
@@ -141,7 +141,10 @@ public class CdCommand : CommandBase
 
     private static IVirtualFileSystem GetVirtualFileSystem(CommandContext context)
     {
-        // This would be injected through DI in a real implementation
-        throw new NotImplementedException("VFS access needs proper DI integration");
+        // Access the file system exposed by the current shell via the context.
+        if (context.FileSystem == null)
+            throw new InvalidOperationException("File system not available in command context");
+
+        return context.FileSystem;
     }
 }

--- a/wasm2/HackerOs/HackerOs/OS/Shell/Commands/LsCommand.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Shell/Commands/LsCommand.cs
@@ -232,8 +232,10 @@ public class LsCommand : CommandBase
 
     private static IVirtualFileSystem GetVirtualFileSystem(CommandContext context)
     {
-        // This would be injected through DI in a real implementation
-        // For now, we'll access it through the shell or context
-        throw new NotImplementedException("VFS access needs proper DI integration");
+        // Access the VFS from the shell via the command context
+        if (context.FileSystem == null)
+            throw new InvalidOperationException("File system not available in command context");
+
+        return context.FileSystem;
     }
 }

--- a/wasm2/HackerOs/HackerOs/OS/Shell/Commands/MkdirCommand.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Shell/Commands/MkdirCommand.cs
@@ -196,7 +196,10 @@ public class MkdirCommand : CommandBase
 
     private static IVirtualFileSystem GetVirtualFileSystem(CommandContext context)
     {
-        // This would be injected through DI in a real implementation
-        throw new NotImplementedException("VFS access needs proper DI integration");
+        // Access the file system provided by the shell
+        if (context.FileSystem == null)
+            throw new InvalidOperationException("File system not available in command context");
+
+        return context.FileSystem;
     }
 }

--- a/wasm2/HackerOs/HackerOs/OS/Shell/Commands/TouchCommand.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Shell/Commands/TouchCommand.cs
@@ -118,7 +118,10 @@ public class TouchCommand : CommandBase
 
     private static IVirtualFileSystem GetVirtualFileSystem(CommandContext context)
     {
-        // This would be injected through DI in a real implementation
-        throw new NotImplementedException("VFS access needs proper DI integration");
+        // Use the file system exposed by the shell
+        if (context.FileSystem == null)
+            throw new InvalidOperationException("File system not available in command context");
+
+        return context.FileSystem;
     }
 }


### PR DESCRIPTION
## Summary
- remove leftover NotImplementedException usage in shell commands
- access virtual file system via `CommandContext.FileSystem`

## Testing
- `npm run build:debug` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68463533cd10832397649d84145e7efa