### PR TITLE
Fix missing methods in HackerOS

### DIFF
--- a/wasm2/HackerOs/HackerOs/OS/Applications/ApplicationManager.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Applications/ApplicationManager.cs
@@ -263,6 +263,12 @@ public class ApplicationManager : IApplicationManager
     }
 
     /// <inheritdoc />
+    public IApplication? GetRunningApplication(string applicationId)
+    {
+        return _runningApplications.Values.FirstOrDefault(a => a.Id == applicationId);
+    }
+
+    /// <inheritdoc />
     public async Task<bool> TerminateApplicationAsync(string applicationId, bool force = false)
     {
         try

--- a/wasm2/HackerOs/HackerOs/OS/Applications/ApplicationUpdater.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Applications/ApplicationUpdater.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
+using HackerOs.OS.Settings;
 
 namespace HackerOs.OS.Applications;
 

--- a/wasm2/HackerOs/HackerOs/OS/Applications/IApplicationManager.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Applications/IApplicationManager.cs
@@ -86,6 +86,13 @@ public interface IApplicationManager
     IApplication? GetRunningApplication(int processId);
 
     /// <summary>
+    /// Get a running application instance by its application ID
+    /// </summary>
+    /// <param name="applicationId">The application identifier</param>
+    /// <returns>Application instance if found, null otherwise</returns>
+    IApplication? GetRunningApplication(string applicationId);
+
+    /// <summary>
     /// Terminate a specific application
     /// </summary>
     /// <param name="applicationId">Application ID to terminate</param>

--- a/wasm2/HackerOs/HackerOs/OS/Shell/Commands/CpCommand.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Shell/Commands/CpCommand.cs
@@ -135,8 +135,8 @@ namespace HackerOs.OS.Shell.Commands
                 }
             }
 
-            var output = string.Join(System.Environment.NewLine, results);
-            var errorOutput = string.Join(System.Environment.NewLine, errors);
+            var output = string.Join(global::System.Environment.NewLine, results);
+            var errorOutput = string.Join(global::System.Environment.NewLine, errors);
 
             if (errors.Any())
             {

--- a/wasm2/HackerOs/HackerOs/OS/UI/ApplicationWindowManager.cs
+++ b/wasm2/HackerOs/HackerOs/OS/UI/ApplicationWindowManager.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using System.Linq;
 
 namespace HackerOs.OS.UI
@@ -173,6 +174,54 @@ namespace HackerOs.OS.UI
         public IReadOnlyCollection<ApplicationWindow> GetAllApplicationWindows()
         {
             return _applicationWindows.Values.ToList().AsReadOnly();
+        }
+
+        /// <summary>
+        /// Gets all windows associated with a specific application.
+        /// </summary>
+        public IReadOnlyCollection<ApplicationWindow> GetWindowsForApplication(string applicationId)
+        {
+            return _applicationWindows.Values
+                .Where(w => w.Application.Id == applicationId)
+                .ToList()
+                .AsReadOnly();
+        }
+
+        /// <summary>
+        /// Brings the application's window to the front.
+        /// </summary>
+        public void BringToFront(string applicationId)
+        {
+            var window = GetApplicationWindow(applicationId);
+            if (window != null)
+            {
+                _windowManager.BringToFront(window.WindowInfo.Id);
+            }
+        }
+
+        /// <summary>
+        /// Minimizes the application's window.
+        /// </summary>
+        public async Task MinimizeApplication(string applicationId)
+        {
+            var window = GetApplicationWindow(applicationId);
+            if (window != null)
+            {
+                await _windowManager.MinimizeWindowAsync(window.WindowInfo.Id);
+            }
+        }
+
+        /// <summary>
+        /// Restores a minimized application window.
+        /// </summary>
+        public async Task RestoreApplication(string applicationId)
+        {
+            var window = GetApplicationWindow(applicationId);
+            if (window != null)
+            {
+                await _windowManager.RestoreWindowAsync(window.WindowInfo.Id);
+                BringToFront(applicationId);
+            }
         }
 
         /// <summary>

--- a/wasm2/HackerOs/HackerOs/OS/UI/Components/ApplicationWindowBase.cs
+++ b/wasm2/HackerOs/HackerOs/OS/UI/Components/ApplicationWindowBase.cs
@@ -64,7 +64,8 @@ namespace HackerOs.OS.UI.Components
                 }
 
                 // Look up the application
-                Application = ApplicationManager.GetApplicationById(ApplicationId);
+                Application = ApplicationManager.GetRunningApplication(ApplicationId) ??
+                              ApplicationManager.GetRunningApplications().FirstOrDefault(a => a.Id == ApplicationId);
                 if (Application == null)
                 {
                     ErrorMessage = $"Application not found: {ApplicationId}";

--- a/wasm2/HackerOs/HackerOs/OS/UI/Components/Desktop.razor.cs
+++ b/wasm2/HackerOs/HackerOs/OS/UI/Components/Desktop.razor.cs
@@ -317,10 +317,10 @@ namespace HackerOs.OS.UI.Components
         /// <summary>
         /// Handle icon double click
         /// </summary>
-        protected void OnIconDoubleClick(MouseEventArgs e, DesktopIcon icon)
+        protected async Task OnIconDoubleClick(MouseEventArgs e, DesktopIcon icon)
         {
             // Launch the application or open the file
-            LaunchIconTarget(icon);
+            await LaunchIconTarget(icon);
             
             // Stop event propagation
             e.StopPropagation();
@@ -466,7 +466,7 @@ namespace HackerOs.OS.UI.Components
                     // Handle open menu item
                     if (ContextMenuIcon != null)
                     {
-                        LaunchIconTarget(ContextMenuIcon);
+                        await LaunchIconTarget(ContextMenuIcon);
                     }
                     break;
                     
@@ -614,7 +614,7 @@ namespace HackerOs.OS.UI.Components
         /// <summary>
         /// Launch the application or open the file associated with the icon
         /// </summary>
-        private void LaunchIconTarget(DesktopIcon icon)
+        private async Task LaunchIconTarget(DesktopIcon icon)
         {
             try
             {
@@ -624,7 +624,9 @@ namespace HackerOs.OS.UI.Components
                     var app = ApplicationManager.GetApplication(icon.Target);
                     if (app != null)
                     {
-                        WindowManager.LaunchApplication(app);
+                        var session = UserSession ?? new UserSession(UserManager.SystemUser, "system");
+                        var context = ApplicationLaunchContext.Create(session);
+                        await ApplicationManager.LaunchApplicationAsync(app.Id, context);
                     }
                     else
                     {

--- a/wasm2/HackerOs/HackerOs/OS/UI/Components/NotificationCenter.razor.cs
+++ b/wasm2/HackerOs/HackerOs/OS/UI/Components/NotificationCenter.razor.cs
@@ -1,6 +1,7 @@
 using HackerOs.OS.UI.Models;
 using HackerOs.OS.UI.Services;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -101,7 +102,7 @@ namespace HackerOs.OS.UI.Components
         /// </summary>
         protected async Task MarkAllAsRead()
         {
-            await NotificationService.MarkAllAsReadAsync();
+            await NotificationService.MarkAllNotificationsAsReadAsync();
             
             // Update local notifications
             foreach (var notification in _notifications)
@@ -117,7 +118,7 @@ namespace HackerOs.OS.UI.Components
         /// </summary>
         protected async Task MarkAsRead(string notificationId)
         {
-            await NotificationService.MarkAsReadAsync(notificationId);
+            await NotificationService.MarkNotificationAsReadAsync(notificationId);
             
             // Update local notification
             var notification = _notifications.FirstOrDefault(n => n.Id == notificationId);
@@ -180,6 +181,43 @@ namespace HackerOs.OS.UI.Components
             {
                 return timestamp.ToString("MMM d, yyyy");
             }
+        }
+
+        /// <summary>
+        /// Helper used by the UI to display a relative time string.
+        /// </summary>
+        /// <param name="timestamp">Notification time stamp</param>
+        /// <returns>Formatted relative time string</returns>
+        protected string GetTimeAgo(DateTime timestamp) => GetFormattedTime(timestamp);
+
+        /// <summary>
+        /// Called when a notification is clicked. Marks it as read and closes the center.
+        /// </summary>
+        /// <param name="notification">The clicked notification</param>
+        protected async Task OnNotificationClick(NotificationModel notification)
+        {
+            await MarkAsRead(notification.Id);
+            CloseNotificationCenter();
+        }
+
+        /// <summary>
+        /// Called when an action button on a notification is clicked.
+        /// </summary>
+        protected async Task OnNotificationActionClick(MouseEventArgs e, NotificationModel notification, NotificationAction action)
+        {
+            await MarkAsRead(notification.Id);
+            if (action.DismissesNotification)
+            {
+                await ClearNotification(notification.Id);
+            }
+        }
+
+        /// <summary>
+        /// Dismisses a notification by id.
+        /// </summary>
+        protected async Task DismissNotification(string id)
+        {
+            await ClearNotification(id);
         }
 
         /// <summary>

--- a/wasm2/HackerOs/HackerOs/OS/UI/Components/Taskbar.razor.cs
+++ b/wasm2/HackerOs/HackerOs/OS/UI/Components/Taskbar.razor.cs
@@ -1,6 +1,7 @@
 using HackerOs.OS.UI.Models;
 using HackerOs.OS.UI.Services;
 using HackerOs.OS.Applications;
+using BlazorWindowManager.Models;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using System;
@@ -353,11 +354,12 @@ namespace HackerOs.OS.UI.Components
         private void OnApplicationStateChanged(object? sender, ApplicationStateChangedEventArgs e)
         {
             // Update the application state in the taskbar
-            var app = RunningApplications.FirstOrDefault(a => a.Id == e.ApplicationId);
+            var app = RunningApplications.FirstOrDefault(a => a.Id == e.Application.Id);
             if (app != null)
             {
-                app.IsActive = e.IsActive;
-                app.IsMinimized = e.IsMinimized;
+                var window = WindowManager.GetApplicationWindow(app.Id);
+                app.IsActive = window?.WindowInfo.IsActive ?? false;
+                app.IsMinimized = window?.WindowInfo.State == WindowState.Minimized;
                 InvokeAsync(StateHasChanged);
             }
         }


### PR DESCRIPTION
## Summary
- implement helper methods for NotificationCenter
- implement running application lookup and window manager actions
- handle launching apps from Desktop
- fix extension method imports and namespace issues
- adjust environment references

## Testing
- `dotnet build HackerOs.sln -c Release` *(fails: 203 errors)*

------
https://chatgpt.com/codex/tasks/task_b_68463bed90f0832395a507ec511f4e92