### PR TITLE
Fix compilation issues in HackerOs

### DIFF
--- a/wasm2/HackerOs/HackerOs/OS/Applications/ApplicationInstaller.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Applications/ApplicationInstaller.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using HackerOs.OS.IO.FileSystem;
 using HackerOs.OS.User;
+using HackerOs.OS.IO.Utilities;
 using Microsoft.Extensions.Logging;
 
 namespace HackerOs.OS.Applications;
@@ -416,7 +417,7 @@ public class ApplicationInstaller : IApplicationInstaller
                 // System-wide installation
                 appDir = string.Format(APP_DATA_DIR, app.Id);
                 manifestDir = SYSTEM_APPS_DIR;
-                manifestPath = Path.Combine(manifestDir, $"{app.Id}.app.json");
+                manifestPath = System.IO.Path.Combine(manifestDir, $"{app.Id}.app.json");
             }
             else
             {
@@ -427,7 +428,7 @@ public class ApplicationInstaller : IApplicationInstaller
                 // User-specific installation
                 appDir = string.Format(USER_APP_DATA_DIR, username, app.Id);
                 manifestDir = string.Format(USER_APPS_DIR, username);
-                manifestPath = Path.Combine(manifestDir, $"{app.Id}.app.json");
+                manifestPath = System.IO.Path.Combine(manifestDir, $"{app.Id}.app.json");
             }
             
             // Delete application files
@@ -492,14 +493,14 @@ public class ApplicationInstaller : IApplicationInstaller
             }
             
             // Find all manifest files
-            var manifestFiles = await _fileSystem.GetFilesAsync(userAppsDir, "*.app.json", User.User.CurrentLogedUser);
+            var manifestFiles = await HackerOs.OS.IO.Utilities.Directory.GetFilesAsync(userAppsDir, "*.app.json", _fileSystem);
             
             // Load each manifest
             foreach (var manifestFile in manifestFiles)
             {
                 try
                 {
-                    string json = await _fileSystem.ReadAllTextAsync(manifestFile);
+                    string json = await _fileSystem.ReadAllTextAsync(manifestFile, UserManager.SystemUser);
                     var manifest = JsonSerializer.Deserialize<ApplicationManifest>(json);
                     
                     if (manifest != null)

--- a/wasm2/HackerOs/HackerOs/OS/Applications/ApplicationUpdater.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Applications/ApplicationUpdater.cs
@@ -1,5 +1,6 @@
 using HackerOs.OS.IO.FileSystem;
 using HackerOs.OS.User;
+using HackerOs.OS.IO.Utilities;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -431,7 +432,7 @@ public class ApplicationUpdater : IApplicationUpdater
             }
             
             // Get version directories
-            var directories = await _fileSystem.GetDirectoriesAsync(appUpdateDir, UserManager.SystemUser);
+            var directories = await HackerOs.OS.IO.Utilities.Directory.GetDirectoriesAsync(appUpdateDir, _fileSystem);
             versions.AddRange(directories.Select(System.IO.Path.GetFileName));
             
             return versions;

--- a/wasm2/HackerOs/HackerOs/OS/Applications/Extensions/FileOpenExtensions.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Applications/Extensions/FileOpenExtensions.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading.Tasks;
 using HackerOs.OS.IO.FileSystem;
 using HackerOs.OS.User;
+using HackerOs.OS.IO.Utilities;
 
 namespace HackerOs.OS.Applications.Extensions;
 
@@ -36,7 +37,7 @@ public static class FileOpenExtensions
         try
         {
             // Normalize path and check if file exists
-            var normalizedPath = fileSystem.NormalizePath(filePath);
+            var normalizedPath = HackerOs.OS.IO.Utilities.Path.NormalizePath(filePath);
             if (!await fileSystem.FileExistsAsync(normalizedPath))
             {
                 return false;
@@ -105,7 +106,7 @@ public static class FileOpenExtensions
         try
         {
             // Normalize path and check if file exists
-            var normalizedPath = fileSystem.NormalizePath(filePath);
+            var normalizedPath = HackerOs.OS.IO.Utilities.Path.NormalizePath(filePath);
             if (!await fileSystem.FileExistsAsync(normalizedPath))
             {
                 return false;

--- a/wasm2/HackerOs/HackerOs/OS/Applications/FileTypeRegistry.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Applications/FileTypeRegistry.cs
@@ -1,6 +1,7 @@
 using HackerOs.OS.Applications.Attributes;
 using HackerOs.OS.IO.FileSystem;
 using HackerOs.OS.User;
+using HackerOs.OS.IO.Utilities;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
@@ -298,11 +299,9 @@ public class FileTypeRegistry : IFileTypeRegistry
             if (string.IsNullOrEmpty(filePath))
                 return null;
                 
-            // Normalize path and get file info
-            var normalizedPath = _fileSystem.NormalizePath(filePath);
-            var fileInfo = await _fileSystem.GetFileInfoAsync(normalizedPath);
-            
-            if (fileInfo == null || !fileInfo.Exists)
+            // Normalize path and verify file exists
+            var normalizedPath = HackerOs.OS.IO.Utilities.Path.NormalizePath(filePath);
+            if (!await _fileSystem.FileExistsAsync(normalizedPath, UserManager.SystemUser))
                 return null;
                 
             // Extract extension

--- a/wasm2/HackerOs/HackerOs/OS/Network/Core/INetworkInterface.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Network/Core/INetworkInterface.cs
@@ -52,6 +52,11 @@ namespace HackerOs.OS.Network.Core
         bool IsUp { get; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the interface is active.
+        /// </summary>
+        bool IsActive { get; }
+
+        /// <summary>
         /// Gets a value indicating whether this interface supports DHCP.
         /// </summary>
         bool SupportsDHCP { get; }

--- a/wasm2/HackerOs/HackerOs/OS/Network/Core/NetworkStack.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Network/Core/NetworkStack.cs
@@ -260,11 +260,11 @@ namespace HackerOs.OS.Network.Core
             {
                 if (intf.Statistics != null)
                 {
-                    stats.PacketsSent += intf.Statistics.PacketsSent;
+                    stats.PacketsSent += intf.Statistics.PacketsTransmitted;
                     stats.PacketsReceived += intf.Statistics.PacketsReceived;
-                    stats.BytesSent += intf.Statistics.BytesSent;
+                    stats.BytesSent += intf.Statistics.BytesTransmitted;
                     stats.BytesReceived += intf.Statistics.BytesReceived;
-                    stats.TrafficByInterface[intf.Name] = intf.Statistics.BytesSent + intf.Statistics.BytesReceived;
+                    stats.TrafficByInterface[intf.Name] = intf.Statistics.BytesTransmitted + intf.Statistics.BytesReceived;
                 }
             }
             

--- a/wasm2/HackerOs/HackerOs/OS/Network/DNS/DnsResolver.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Network/DNS/DnsResolver.cs
@@ -310,8 +310,8 @@ namespace HackerOs.OS.Network.DNS
             var cacheResult = CheckCache(cacheKey, DnsRecordType.PTR);
             if (cacheResult != null)
             {
-                FireQueryProcessedEvent(ipAddress, DnsRecordType.PTR, true, cacheResult.Value, true);
-                return cacheResult.Value;
+                FireQueryProcessedEvent(ipAddress, DnsRecordType.PTR, true, cacheResult, true);
+                return cacheResult;
             }
 
             // Look for matching records

--- a/wasm2/HackerOs/HackerOs/OS/Network/WebServer/Framework/ModelBinder.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Network/WebServer/Framework/ModelBinder.cs
@@ -40,9 +40,9 @@ namespace HackerOs.OS.Network.WebServer.Framework
             // Source dictionaries for binding values
             var sources = new List<Dictionary<string, string>>
             {
-                context.Request.RouteValues,
-                context.Request.QueryParameters,
-                context.Request.Form
+                context.Request.RouteData.ToDictionary(k => k.Key, k => k.Value?.ToString() ?? string.Empty),
+                new Dictionary<string, string>(context.Request.QueryParameters),
+                new Dictionary<string, string>(context.Request.Form)
             };
             
             // Try to bind each property

--- a/wasm2/HackerOs/HackerOs/OS/System/Net/Http/HttpClient.cs
+++ b/wasm2/HackerOs/HackerOs/OS/System/Net/Http/HttpClient.cs
@@ -279,7 +279,7 @@ namespace HackerOs.OS.System.Net.Http
         }        public override Task<System.IO.Stream> ReadAsStreamAsync()
         {
             var bytes = System.Text.Encoding.UTF8.GetBytes(_content);
-            return Task.FromResult<System.IO.Stream>(new System.IO.MemoryStream(bytes));
+            return Task.FromResult<System.IO.Stream>(new global::System.IO.MemoryStream(bytes));
         }
     }
 

--- a/wasm2/HackerOs/HackerOs/OS/System/Net/Http/Json/JsonExtensions.cs
+++ b/wasm2/HackerOs/HackerOs/OS/System/Net/Http/Json/JsonExtensions.cs
@@ -14,7 +14,7 @@ namespace HackerOs.OS.System.Net.Http.Json
         /// <summary>
         /// Sends a GET request to the specified Uri and returns the value as a JSON string
         /// </summary>
-        public static async Task<T?> GetFromJsonAsync<T>(this HttpClient client, string requestUri, JsonSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default)
+        public static async Task<T?> GetFromJsonAsync<T>(this HttpClient client, string requestUri, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
         {
             var response = await client.GetAsync(requestUri, cancellationToken);
             response.EnsureSuccessStatusCode();
@@ -29,54 +29,54 @@ namespace HackerOs.OS.System.Net.Http.Json
         /// <summary>
         /// Sends a GET request to the specified Uri and returns the value as a JSON string
         /// </summary>
-        public static async Task<T?> GetFromJsonAsync<T>(this HttpClient client, Uri requestUri, JsonSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default)
+        public static async Task<T?> GetFromJsonAsync<T>(this HttpClient client, Uri requestUri, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
         {
-            return await GetFromJsonAsync<T>(client, requestUri.ToString(), options, cancellationToken);
+            return await GetFromJsonAsync<T>(client, requestUri.ToString(), cancellationToken, options);
         }
 
         /// <summary>
         /// Sends a POST request to the specified Uri containing the value serialized as JSON
         /// </summary>
-        public static async Task<HttpResponseMessage> PostAsJsonAsync<T>(this HttpClient client, string requestUri, T value, JsonSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default)
+        public static async Task<HttpResponseMessage> PostAsJsonAsync<T>(this HttpClient client, string requestUri, T value, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
         {
             var json = JsonSerializer.Serialize(value, options);
-            var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+            var content = new StringContent(json, "utf-8", "application/json");
             return await client.PostAsync(requestUri, content, cancellationToken);
         }
 
         /// <summary>
         /// Sends a POST request to the specified Uri containing the value serialized as JSON
         /// </summary>
-        public static async Task<HttpResponseMessage> PostAsJsonAsync<T>(this HttpClient client, Uri requestUri, T value, JsonSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default)
+        public static async Task<HttpResponseMessage> PostAsJsonAsync<T>(this HttpClient client, Uri requestUri, T value, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
         {
-            return await PostAsJsonAsync(client, requestUri.ToString(), value, options, cancellationToken);
+            return await PostAsJsonAsync(client, requestUri.ToString(), value, cancellationToken, options);
         }
 
         /// <summary>
         /// Sends a PUT request to the specified Uri containing the value serialized as JSON
         /// </summary>
-        public static async Task<HttpResponseMessage> PutAsJsonAsync<T>(this HttpClient client, string requestUri, T value, JsonSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default)
+        public static async Task<HttpResponseMessage> PutAsJsonAsync<T>(this HttpClient client, string requestUri, T value, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
         {
             var json = JsonSerializer.Serialize(value, options);
-            var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+            var content = new StringContent(json, "utf-8", "application/json");
             return await client.PutAsync(requestUri, content, cancellationToken);
         }
 
         /// <summary>
         /// Sends a PUT request to the specified Uri containing the value serialized as JSON
         /// </summary>
-        public static async Task<HttpResponseMessage> PutAsJsonAsync<T>(this HttpClient client, Uri requestUri, T value, JsonSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default)
+        public static async Task<HttpResponseMessage> PutAsJsonAsync<T>(this HttpClient client, Uri requestUri, T value, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
         {
-            return await PutAsJsonAsync(client, requestUri.ToString(), value, options, cancellationToken);
+            return await PutAsJsonAsync(client, requestUri.ToString(), value, cancellationToken, options);
         }
 
         /// <summary>
         /// Sends a PATCH request to the specified Uri containing the value serialized as JSON
         /// </summary>
-        public static async Task<HttpResponseMessage> PatchAsJsonAsync<T>(this HttpClient client, string requestUri, T value, JsonSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default)
+        public static async Task<HttpResponseMessage> PatchAsJsonAsync<T>(this HttpClient client, string requestUri, T value, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
         {
             var json = JsonSerializer.Serialize(value, options);
-            var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+            var content = new StringContent(json, "utf-8", "application/json");
             var request = new HttpRequestMessage(new HttpMethod("PATCH"), requestUri)
             {
                 Content = content
@@ -87,9 +87,9 @@ namespace HackerOs.OS.System.Net.Http.Json
         /// <summary>
         /// Sends a PATCH request to the specified Uri containing the value serialized as JSON
         /// </summary>
-        public static async Task<HttpResponseMessage> PatchAsJsonAsync<T>(this HttpClient client, Uri requestUri, T value, JsonSerializerOptions? options = null, System.Threading.CancellationToken cancellationToken = default)
+        public static async Task<HttpResponseMessage> PatchAsJsonAsync<T>(this HttpClient client, Uri requestUri, T value, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
         {
-            return await PatchAsJsonAsync(client, requestUri.ToString(), value, options, cancellationToken);
+            return await PatchAsJsonAsync(client, requestUri.ToString(), value, cancellationToken, options);
         }
     }
 
@@ -121,14 +121,14 @@ namespace HackerOs.OS.System.Net.Http.Json
         /// </summary>
         public async Task SerializeToStreamAsync(System.IO.Stream stream, TransportContext? context = null)
         {
-            var bytes = System.Text.Encoding.UTF8.GetBytes(_jsonContent);
+            var bytes = global::System.Text.Encoding.UTF8.GetBytes(_jsonContent);
             await stream.WriteAsync(bytes, 0, bytes.Length);
         }/// <summary>
         /// Determines whether the HTTP content has a valid length in bytes
         /// </summary>
         public bool TryComputeLength(out long length)
         {
-            length = System.Text.Encoding.UTF8.GetByteCount(_jsonContent);
+            length = global::System.Text.Encoding.UTF8.GetByteCount(_jsonContent);
             return true;
         }
 
@@ -137,7 +137,7 @@ namespace HackerOs.OS.System.Net.Http.Json
         /// </summary>
         public override async Task<byte[]> ReadAsByteArrayAsync()
         {
-            return System.Text.Encoding.UTF8.GetBytes(_jsonContent);
+            return global::System.Text.Encoding.UTF8.GetBytes(_jsonContent);
         }
 
         /// <summary>
@@ -153,7 +153,7 @@ namespace HackerOs.OS.System.Net.Http.Json
         /// </summary>
         public override async Task<System.IO.Stream> ReadAsStreamAsync()
         {
-            var bytes = System.Text.Encoding.UTF8.GetBytes(_jsonContent);
+            var bytes = global::System.Text.Encoding.UTF8.GetBytes(_jsonContent);
             return new System.IO.MemoryStream(bytes);
         }
     }

--- a/wasm2/HackerOs/HackerOs/OS/UI/Components/ApplicationLauncher.razor.cs
+++ b/wasm2/HackerOs/HackerOs/OS/UI/Components/ApplicationLauncher.razor.cs
@@ -1,6 +1,7 @@
 using HackerOs.OS.Applications;
 using HackerOs.OS.UI.Models;
 using HackerOs.OS.UI.Services;
+using HackerOs.OS.User;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.Logging;
@@ -19,6 +20,7 @@ namespace HackerOs.OS.UI.Components
         [Inject] protected IApplicationManager ApplicationManager { get; set; } = null!;
         [Inject] protected LauncherService LauncherService { get; set; } = null!;
         [Inject] protected ILogger<ApplicationLauncher> Logger { get; set; } = null!;
+        [Inject] protected IUserManager UserManager { get; set; } = null!;
 
         /// <summary>
         /// Event called when the launcher open state changes
@@ -192,8 +194,10 @@ namespace HackerOs.OS.UI.Components
                 _isOpen = false;
                 await OnLauncherOpenChanged.InvokeAsync(false);
                 
-                // Launch the application
-                await ApplicationManager.LaunchApplicationAsync(appId);
+                // Launch the application with a basic context
+                var session = new UserSession(UserManager.SystemUser, "system");
+                var context = ApplicationLaunchContext.Create(session);
+                await ApplicationManager.LaunchApplicationAsync(appId, context);
                 
                 // Track as recently used
                 await LauncherService.RecordApplicationLaunchAsync(appId);


### PR DESCRIPTION
## Summary
- fix various compilation errors in HackerOs project
- add missing `IsActive` property on network interface
- correct file path utilities and application launcher context
- cleanup HTTP JSON extension signatures

## Testing
- `dotnet build wasm2/HackerOs/HackerOs.sln -c Release` *(fails: 157 errors)*

------
https://chatgpt.com/codex/tasks/task_b_684663bd51348323a2d7c2e7b3a541af