### PR TITLE
Fix UI event handlers

### DIFF
--- a/wasm2/HackerOs/HackerOs/OS/UI/Components/ApplicationLauncher.razor.cs
+++ b/wasm2/HackerOs/HackerOs/OS/UI/Components/ApplicationLauncher.razor.cs
@@ -18,6 +18,7 @@ namespace HackerOs.OS.UI.Components
     public partial class ApplicationLauncher : ComponentBase, IDisposable
     {
         [Inject] protected IApplicationManager ApplicationManager { get; set; } = null!;
+        [Inject] protected IApplicationInstaller ApplicationInstaller { get; set; } = null!;
         [Inject] protected LauncherService LauncherService { get; set; } = null!;
         [Inject] protected ILogger<ApplicationLauncher> Logger { get; set; } = null!;
         [Inject] protected IUserManager UserManager { get; set; } = null!;
@@ -73,10 +74,10 @@ namespace HackerOs.OS.UI.Components
         protected override async Task OnInitializedAsync()
         {
             // Subscribe to application events
-            ApplicationManager.ApplicationInstalled += OnApplicationInstalled;
-            ApplicationManager.ApplicationUninstalled += OnApplicationUninstalled;
-            ApplicationManager.ApplicationStarted += OnApplicationStarted;
-            ApplicationManager.ApplicationClosed += OnApplicationClosed;
+            ApplicationInstaller.ApplicationInstalled += OnApplicationInstalled;
+            ApplicationInstaller.ApplicationUninstalled += OnApplicationUninstalled;
+            ApplicationManager.ApplicationLaunched += OnApplicationStarted;
+            ApplicationManager.ApplicationTerminated += OnApplicationClosed;
 
             // Load initial data
             await LoadDataAsync();
@@ -90,10 +91,10 @@ namespace HackerOs.OS.UI.Components
         public void Dispose()
         {
             // Unsubscribe from events
-            ApplicationManager.ApplicationInstalled -= OnApplicationInstalled;
-            ApplicationManager.ApplicationUninstalled -= OnApplicationUninstalled;
-            ApplicationManager.ApplicationStarted -= OnApplicationStarted;
-            ApplicationManager.ApplicationClosed -= OnApplicationClosed;
+            ApplicationInstaller.ApplicationInstalled -= OnApplicationInstalled;
+            ApplicationInstaller.ApplicationUninstalled -= OnApplicationUninstalled;
+            ApplicationManager.ApplicationLaunched -= OnApplicationStarted;
+            ApplicationManager.ApplicationTerminated -= OnApplicationClosed;
         }
 
         /// <summary>
@@ -195,7 +196,7 @@ namespace HackerOs.OS.UI.Components
                 await OnLauncherOpenChanged.InvokeAsync(false);
                 
                 // Launch the application with a basic context
-                var session = new UserSession(UserManager.SystemUser, "system");
+                var session = new UserSession(HackerOs.OS.User.UserManager.SystemUser, "system");
                 var context = ApplicationLaunchContext.Create(session);
                 await ApplicationManager.LaunchApplicationAsync(appId, context);
                 

--- a/wasm2/HackerOs/HackerOs/OS/UI/Components/ApplicationWindowBase.cs
+++ b/wasm2/HackerOs/HackerOs/OS/UI/Components/ApplicationWindowBase.cs
@@ -33,7 +33,10 @@ namespace HackerOs.OS.UI.Components
         /// <summary>
         /// The application window bridge
         /// </summary>
-        protected ApplicationWindow? ApplicationWindow { get; private set; }
+        /// <summary>
+        /// Bridge object between the application and its window
+        /// </summary>
+        protected HackerOs.OS.UI.ApplicationWindow? AppWindowBridge { get; private set; }
 
         /// <summary>
         /// Error message if application can't be loaded
@@ -73,8 +76,8 @@ namespace HackerOs.OS.UI.Components
                 }
 
                 // Get the application window
-                ApplicationWindow = WindowManager.GetApplicationWindow(ApplicationId);
-                if (ApplicationWindow == null)
+                AppWindowBridge = WindowManager.GetApplicationWindow(ApplicationId);
+                if (AppWindowBridge == null)
                 {
                     ErrorMessage = $"Application window not found: {ApplicationId}";
                     return;

--- a/wasm2/HackerOs/HackerOs/OS/UI/Components/Desktop.razor.cs
+++ b/wasm2/HackerOs/HackerOs/OS/UI/Components/Desktop.razor.cs
@@ -178,7 +178,7 @@ namespace HackerOs.OS.UI.Components
         /// <summary>
         /// Handle theme changes
         /// </summary>
-        private void OnThemeChanged(object? sender, ThemeChangedEventArgs e)
+        private void OnThemeChanged(object? sender, EventArgs e)
         {
             StateHasChanged();
         }
@@ -308,8 +308,7 @@ namespace HackerOs.OS.UI.Components
             // Hide context menu
             IsContextMenuVisible = false;
             
-            // Stop event propagation
-            e.StopPropagation();
+
             
             StateHasChanged();
         }
@@ -322,8 +321,7 @@ namespace HackerOs.OS.UI.Components
             // Launch the application or open the file
             await LaunchIconTarget(icon);
             
-            // Stop event propagation
-            e.StopPropagation();
+
         }
 
         /// <summary>
@@ -355,8 +353,7 @@ namespace HackerOs.OS.UI.Components
                 IsDragging = true;
             }
             
-            // Stop event propagation
-            e.StopPropagation();
+
         }
 
         /// <summary>
@@ -383,8 +380,7 @@ namespace HackerOs.OS.UI.Components
             IsContextMenuVisible = true;
             StateHasChanged();
             
-            // Stop event propagation
-            e.StopPropagation();
+
         }
 
         #endregion

--- a/wasm2/HackerOs/HackerOs/OS/UI/Components/NotificationCenter.razor.cs
+++ b/wasm2/HackerOs/HackerOs/OS/UI/Components/NotificationCenter.razor.cs
@@ -146,7 +146,7 @@ namespace HackerOs.OS.UI.Components
         /// </summary>
         private async Task LoadNotifications()
         {
-            _notifications = (await NotificationService.GetNotificationsAsync()).ToList();
+            _notifications = NotificationService.GetNotifications().ToList();
             StateHasChanged();
         }
 


### PR DESCRIPTION
## Summary
- fix `ApplicationWindowBase` variable type to avoid collision with component
- hook up `ApplicationLauncher` to correct installer and manager events
- rely on static `UserManager.SystemUser`
- remove dead `StopPropagation` calls and adjust theme event signature
- load notifications via existing sync method

## Testing
- `dotnet build HackerOs.sln` *(fails: 93 errors)*

------
https://chatgpt.com/codex/tasks/task_b_68466b87100883239b314c70b8370cf7