### PR TITLE
Fix compile issues

### DIFF
--- a/wasm2/HackerOs/HackerOs/OS/Settings/SettingsServiceExtensions.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Settings/SettingsServiceExtensions.cs
@@ -1,0 +1,24 @@
+using HackerOs.OS.Settings;
+using HackerOsUser = HackerOs.OS.User.User;
+
+namespace HackerOs.OS.Settings
+{
+    /// <summary>
+    /// Extension methods for <see cref="ISettingsService"/>
+    /// to simplify retrieval of <see cref="UserSettings"/> instances.
+    /// </summary>
+    public static class SettingsServiceExtensions
+    {
+        /// <summary>
+        /// Gets a <see cref="UserSettings"/> wrapper for the specified user.
+        /// </summary>
+        /// <param name="service">The underlying settings service.</param>
+        /// <param name="user">The user for which to retrieve settings.</param>
+        public static UserSettings GetUserSettings(this ISettingsService service, HackerOsUser user)
+        {
+            var systemSettings = new SystemSettings(service, Microsoft.Extensions.Logging.Abstractions.NullLogger<SystemSettings>.Instance);
+            var logger = Microsoft.Extensions.Logging.Abstractions.NullLogger<UserSettings>.Instance;
+            return new UserSettings(service, systemSettings, logger, user.Username);
+        }
+    }
+}

--- a/wasm2/HackerOs/HackerOs/OS/UI/ApplicationWindow.cs
+++ b/wasm2/HackerOs/HackerOs/OS/UI/ApplicationWindow.cs
@@ -151,20 +151,18 @@ namespace HackerOs.OS.UI
 
                 var x = settings.GetValue<double>($"app.{_application.Id}.window.x", defaultX);
                 var y = settings.GetValue<double>($"app.{_application.Id}.window.y", defaultY);
-                _windowInfo.Bounds = new WindowBounds(x, y)
+
+                var bounds = new WindowBounds(x, y)
                 {
                     Width = settings.GetValue<double>($"app.{_application.Id}.window.width", 800),
                     Height = settings.GetValue<double>($"app.{_application.Id}.window.height", 600)
                 };
-                _windowInfo.Bounds.Width = settings.GetValue<double>($"app.{_application.Id}.window.width", 800);
-                _windowInfo.Bounds.Height = settings.GetValue<double>($"app.{_application.Id}.window.height", 600);
 
                 var savedState = settings.GetValue<int>($"app.{_application.Id}.window.state", 0);
-                _windowInfo.State = (WindowState)savedState;
+                var state = (WindowState)savedState;
 
-                // Update window in manager
-                _windowManager.UpdateWindowBounds(_windowInfo.Id, _windowInfo.Bounds);
-                _windowManager.UpdateWindowState(_windowInfo.Id, _windowInfo.State);
+                _windowManager.UpdateWindowBounds(_windowInfo.Id, bounds);
+                _windowManager.UpdateWindowState(_windowInfo.Id, state);
 
                 _logger.LogDebug("Restored window state for application {AppId}", _application.Id);
             }
@@ -214,7 +212,7 @@ namespace HackerOs.OS.UI
         private void UpdateWindowFromApplication()
         {
             // Update window title
-            _windowInfo.Title = _application.Name;
+            _windowManager.UpdateWindowTitle(_windowInfo.Id, _application.Name);
 
             // Update window state based on application state
             switch (_application.State)


### PR DESCRIPTION
## Summary
- fix ApplicationWindow to use WindowManager updates instead of setting read-only properties
- add SettingsServiceExtensions helper to obtain UserSettings

## Testing
- `dotnet build HackerOs.sln -c Release` *(fails: CS0029 etc.)*

------
https://chatgpt.com/codex/tasks/task_b_6846715f09b883239daba39b970bed85