### PR TITLE
Fix path utils and DNS file access

### DIFF
--- a/wasm2/HackerOs/HackerOs/OS/Applications/Extensions/FileOpenExtensions.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Applications/Extensions/FileOpenExtensions.cs
@@ -37,14 +37,15 @@ public static class FileOpenExtensions
         try
         {
             // Normalize path and check if file exists
-            var normalizedPath = HackerOs.OS.IO.Utilities.Path.NormalizePath(filePath);
+            // Normalize path using the public utility available for the virtual file system
+            var normalizedPath = HackerOs.OS.System.IO.Path.NormalizePath(filePath);
             if (!await fileSystem.FileExistsAsync(normalizedPath))
             {
                 return false;
             }
             
             // Get file extension
-            var extension = Path.GetExtension(normalizedPath);
+            var extension = System.IO.Path.GetExtension(normalizedPath);
             if (string.IsNullOrEmpty(extension))
             {
                 return false;
@@ -66,7 +67,7 @@ public static class FileOpenExtensions
             {
                 UserSession = userSession,
                 Arguments = new[] { normalizedPath },
-                WorkingDirectory = Path.GetDirectoryName(normalizedPath)
+                WorkingDirectory = System.IO.Path.GetDirectoryName(normalizedPath)
             };
             
             var app = await applicationManager.LaunchApplicationAsync(appId, context);
@@ -106,7 +107,8 @@ public static class FileOpenExtensions
         try
         {
             // Normalize path and check if file exists
-            var normalizedPath = HackerOs.OS.IO.Utilities.Path.NormalizePath(filePath);
+            // Normalize path using the public utility so callers don't rely on private helpers
+            var normalizedPath = HackerOs.OS.System.IO.Path.NormalizePath(filePath);
             if (!await fileSystem.FileExistsAsync(normalizedPath))
             {
                 return false;
@@ -117,7 +119,7 @@ public static class FileOpenExtensions
             {
                 UserSession = userSession,
                 Arguments = new[] { normalizedPath },
-                WorkingDirectory = Path.GetDirectoryName(normalizedPath)
+                WorkingDirectory = System.IO.Path.GetDirectoryName(normalizedPath)
             };
             
             var app = await applicationManager.LaunchApplicationAsync(applicationId, context);
@@ -150,7 +152,7 @@ public static class FileOpenExtensions
         try
         {
             // Get file extension
-            var extension = Path.GetExtension(filePath);
+            var extension = System.IO.Path.GetExtension(filePath);
             if (string.IsNullOrEmpty(extension))
             {
                 return false;

--- a/wasm2/HackerOs/HackerOs/OS/Applications/FileTypeRegistry.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Applications/FileTypeRegistry.cs
@@ -300,7 +300,8 @@ public class FileTypeRegistry : IFileTypeRegistry
                 return null;
                 
             // Normalize path and verify file exists
-            var normalizedPath = HackerOs.OS.IO.Utilities.Path.NormalizePath(filePath);
+            // Use the public NormalizePath method from the virtual file system utilities
+            var normalizedPath = HackerOs.OS.System.IO.Path.NormalizePath(filePath);
             if (!await _fileSystem.FileExistsAsync(normalizedPath, UserManager.SystemUser))
                 return null;
                 

--- a/wasm2/HackerOs/HackerOs/OS/Network/DNS/DnsResolver.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Network/DNS/DnsResolver.cs
@@ -107,9 +107,10 @@ namespace HackerOs.OS.Network.DNS
         {
             try
             {
-                if (await _fileSystem.FileExistsAsync(_hostsFilePath))
+                // Use system-level permissions when interacting with the hosts file
+                if (await _fileSystem.FileExistsAsync(_hostsFilePath, UserManager.SystemUser))
                 {
-                    var hostsContent = await _fileSystem.ReadAllTextAsync(_hostsFilePath);
+                    var hostsContent = await _fileSystem.ReadAllTextAsync(_hostsFilePath, UserManager.SystemUser);
                     await ParseHostsFileAsync(hostsContent);
                     _logger.LogInformation("Loaded hosts file from {Path}", _hostsFilePath);
                 }
@@ -149,12 +150,12 @@ namespace HackerOs.OS.Network.DNS
             {
                 // Ensure the directory exists
                 var directory = HackerOs.OS.System.IO.Path.GetDirectoryName(_hostsFilePath);
-                if (!string.IsNullOrEmpty(directory) && !await _fileSystem.DirectoryExistsAsync(directory))
+                if (!string.IsNullOrEmpty(directory) && !await _fileSystem.DirectoryExistsAsync(directory, UserManager.SystemUser))
                 {
-                    await _fileSystem.CreateDirectoryAsync(directory);
+                    await _fileSystem.CreateDirectoryAsync(directory, UserManager.SystemUser);
                 }
 
-                await _fileSystem.WriteAllTextAsync(_hostsFilePath, defaultContent);
+                await _fileSystem.WriteAllTextAsync(_hostsFilePath, defaultContent, UserManager.SystemUser);
                 _logger.LogInformation("Created default hosts file at {Path}", _hostsFilePath);
                 
                 // Parse the default hosts file


### PR DESCRIPTION
## Summary
- use public path normalization utility
- patch FileOpenExtensions to resolve `Path` ambiguity and use public path utilities
- access hosts file with SystemUser in DnsResolver

## Testing
- `dotnet build HackerOs.sln -c Debug` *(fails: FileRedirectionStream etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68468f9278b083239c21295026638a3e