### PR TITLE
Fix compile issues in HackerOS modules

### DIFF
--- a/wasm2/HackerOs/HackerOs/OS/Applications/ApplicationInstaller.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Applications/ApplicationInstaller.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using HackerOs.OS.IO.FileSystem;
 using HackerOs.OS.User;
 using HackerOs.OS.IO.Utilities;
+using IOPath = HackerOs.OS.IO.Utilities.Path;
 using Microsoft.Extensions.Logging;
 
 namespace HackerOs.OS.Applications;
@@ -186,7 +187,7 @@ public class ApplicationInstaller : IApplicationInstaller
             }
             
             // Ensure log directory exists
-            string logDir = Path.GetDirectoryName(INSTALL_LOG_FILE) ?? "/var/log/hackeros";
+            string logDir = global::System.IO.Path.GetDirectoryName(INSTALL_LOG_FILE) ?? "/var/log/hackeros";
             if (!await _fileSystem.DirectoryExistsAsync(logDir, UserManager.SystemUser))
             {
                 await _fileSystem.CreateDirectoryAsync(logDir, UserManager.SystemUser);
@@ -327,8 +328,8 @@ public class ApplicationInstaller : IApplicationInstaller
             // Install application files
             foreach (var entry in sourceFiles)
             {
-                string destPath = Path.Combine(appDir, entry.Key);
-                string? destDir = Path.GetDirectoryName(destPath);
+                string destPath = global::System.IO.Path.Combine(appDir, entry.Key);
+                string? destDir = global::System.IO.Path.GetDirectoryName(destPath);
                 
                 // Create parent directories if needed
                 if (!string.IsNullOrEmpty(destDir) && !await _fileSystem.DirectoryExistsAsync(destDir, UserManager.SystemUser))
@@ -341,7 +342,7 @@ public class ApplicationInstaller : IApplicationInstaller
             }
             
             // Save the manifest
-            string manifestPath = Path.Combine(manifestDir, $"{manifest.Id}.app.json");
+            string manifestPath = global::System.IO.Path.Combine(manifestDir, $"{manifest.Id}.app.json");
             string json = JsonSerializer.Serialize(manifest);
             await _fileSystem.WriteAllTextAsync(manifestPath, json, UserManager.SystemUser);
             
@@ -417,7 +418,7 @@ public class ApplicationInstaller : IApplicationInstaller
                 // System-wide installation
                 appDir = string.Format(APP_DATA_DIR, app.Id);
                 manifestDir = SYSTEM_APPS_DIR;
-                manifestPath = System.IO.Path.Combine(manifestDir, $"{app.Id}.app.json");
+                manifestPath = global::System.IO.Path.Combine(manifestDir, $"{app.Id}.app.json");
             }
             else
             {
@@ -428,7 +429,7 @@ public class ApplicationInstaller : IApplicationInstaller
                 // User-specific installation
                 appDir = string.Format(USER_APP_DATA_DIR, username, app.Id);
                 manifestDir = string.Format(USER_APPS_DIR, username);
-                manifestPath = System.IO.Path.Combine(manifestDir, $"{app.Id}.app.json");
+                manifestPath = global::System.IO.Path.Combine(manifestDir, $"{app.Id}.app.json");
             }
             
             // Delete application files

--- a/wasm2/HackerOs/HackerOs/OS/Applications/ApplicationManager.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Applications/ApplicationManager.cs
@@ -423,7 +423,28 @@ public class ApplicationManager : IApplicationManager
 
             return _statistics;
         }
-    }    /// <summary>
+    }
+
+    /// <summary>
+    /// Creates a render fragment to display the application's user interface.
+    /// </summary>
+    /// <param name="application">Application instance.</param>
+    public RenderFragment GetApplicationContentRenderer(IApplication application)
+    {
+        if (application is ComponentBase)
+        {
+            var type = application.GetType();
+            return builder =>
+            {
+                builder.OpenComponent(0, type);
+                builder.CloseComponent();
+            };
+        }
+
+        return builder => builder.AddContent(0, $"Application {application.Name} has no UI.");
+    }
+
+    /// <summary>
     /// Create an application instance from a manifest
     /// </summary>
     private async Task<IApplication?> CreateApplicationInstanceAsync(ApplicationManifest manifest, ApplicationLaunchContext context)

--- a/wasm2/HackerOs/HackerOs/OS/Applications/FileTypeRegistry.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Applications/FileTypeRegistry.cs
@@ -300,8 +300,7 @@ public class FileTypeRegistry : IFileTypeRegistry
                 return null;
                 
             // Normalize path and verify file exists
-            // Use the public NormalizePath method from the virtual file system utilities
-            var normalizedPath = HackerOs.OS.System.IO.Path.NormalizePath(filePath);
+            var normalizedPath = Path.GetFullPath(filePath);
             if (!await _fileSystem.FileExistsAsync(normalizedPath, UserManager.SystemUser))
                 return null;
                 

--- a/wasm2/HackerOs/HackerOs/OS/Network/HTTP/HttpServer.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Network/HTTP/HttpServer.cs
@@ -277,7 +277,7 @@ namespace HackerOs.OS.Network.HTTP
                     var receiveBuffer = new byte[8192]; // 8KB buffer
                     
                     // Receive request data
-                    int bytesRead = await clientSocket.ReceiveAsync(receiveBuffer, 0, receiveBuffer.Length);
+                    int bytesRead = await clientSocket.ReceiveAsync(receiveBuffer);
                     
                     if (bytesRead > 0)
                     {
@@ -312,7 +312,7 @@ namespace HackerOs.OS.Network.HTTP
                             "500 Internal Server Error";
                         
                         var errorBytes = Encoding.UTF8.GetBytes(errorResponse);
-                        await clientSocket.SendAsync(errorBytes, 0, errorBytes.Length);
+                        await clientSocket.SendAsync(errorBytes);
                     }
                     catch
                     {
@@ -531,7 +531,7 @@ namespace HackerOs.OS.Network.HTTP
                 var responseBytes = Encoding.UTF8.GetBytes(responseText);
                 
                 // Send the response
-                await clientSocket.SendAsync(responseBytes, 0, responseBytes.Length);
+                await clientSocket.SendAsync(responseBytes);
                 
                 // Log the response
                 _logger.LogDebug("Sent HTTP response: {StatusCode} {Method} {Url}",

--- a/wasm2/HackerOs/HackerOs/OS/Network/WebServer/Framework/Router.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Network/WebServer/Framework/Router.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using HackerOs.OS.Network.HTTP;
+using HttpMethod = HackerOs.OS.Network.HTTP.HttpMethod;
 
 namespace HackerOs.OS.Network.WebServer.Framework
 {

--- a/wasm2/HackerOs/HackerOs/OS/Network/WebServer/Hosting/VirtualHost.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Network/WebServer/Hosting/VirtualHost.cs
@@ -146,7 +146,7 @@ namespace HackerOs.OS.Network.WebServer.Hosting
             // Match the route
             var route = _router.MatchRoute(
                 context.Request.Url.AbsolutePath,
-                context.Request.Method,
+                context.Request.Method.ToString(),
                 out var routeParameters);
             
             if (route != null)
@@ -325,7 +325,7 @@ namespace HackerOs.OS.Network.WebServer.Hosting
         {
             try
             {
-                var sb = new System.Text.StringBuilder();
+                var sb = new global::System.Text.StringBuilder();
                 sb.AppendLine("<!DOCTYPE html>");
                 sb.AppendLine("<html>");
                 sb.AppendLine("<head>");

--- a/wasm2/HackerOs/HackerOs/OS/Settings/ConfigurationBackupService.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Settings/ConfigurationBackupService.cs
@@ -352,7 +352,7 @@ namespace HackerOs.OS.Settings
         private string GenerateVersionHash(string content)
         {
             // Simple hash for version tracking
-            return Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(content)))[..16];
+            return Convert.ToHexString(global::System.Security.Cryptography.SHA256.HashData(global::System.Text.Encoding.UTF8.GetBytes(content)))[..16];
         }
     }
 

--- a/wasm2/HackerOs/HackerOs/OS/UI/Components/ApplicationWindowBase.cs
+++ b/wasm2/HackerOs/HackerOs/OS/UI/Components/ApplicationWindowBase.cs
@@ -41,7 +41,7 @@ namespace HackerOs.OS.UI.Components
         /// <summary>
         /// Error message if application can't be loaded
         /// </summary>
-        protected string? ErrorMessage { get; private set; }
+        protected string? ErrorMessage { get; set; }
 
         /// <summary>
         /// Whether the application is loading

--- a/wasm2/HackerOs/HackerOs/OS/UI/Services/DesktopSettingsService.cs
+++ b/wasm2/HackerOs/HackerOs/OS/UI/Services/DesktopSettingsService.cs
@@ -45,7 +45,7 @@ namespace HackerOs.OS.UI.Services
         /// </summary>
         public async Task<List<DesktopIcon>> GetDesktopIconsAsync()
         {
-            var json = await _settingsService.GetSettingAsync(DESKTOP_ICONS_KEY);
+            var json = await _settingsService.GetSettingAsync<string>(DESKTOP_ICONS_KEY, string.Empty);
             if (string.IsNullOrEmpty(json))
             {
                 return CreateDefaultDesktopIcons();
@@ -68,7 +68,7 @@ namespace HackerOs.OS.UI.Services
         public async Task SaveDesktopIconsAsync(List<DesktopIcon> icons)
         {
             var json = JsonSerializer.Serialize(icons);
-            await _settingsService.SaveSettingAsync(DESKTOP_ICONS_KEY, json);
+            await _settingsService.SetSettingAsync(DESKTOP_ICONS_KEY, json);
         }
 
         /// <summary>
@@ -105,7 +105,7 @@ namespace HackerOs.OS.UI.Services
         /// </summary>
         private async Task<Dictionary<string, string>> GetDesktopSettingsAsync()
         {
-            var json = await _settingsService.GetSettingAsync(DESKTOP_SETTINGS_KEY);
+            var json = await _settingsService.GetSettingAsync<string>(DESKTOP_SETTINGS_KEY, string.Empty);
             if (string.IsNullOrEmpty(json))
             {
                 return CreateDefaultDesktopSettings();
@@ -128,7 +128,7 @@ namespace HackerOs.OS.UI.Services
         private async Task SaveDesktopSettingsAsync(Dictionary<string, string> settings)
         {
             var json = JsonSerializer.Serialize(settings);
-            await _settingsService.SaveSettingAsync(DESKTOP_SETTINGS_KEY, json);
+            await _settingsService.SetSettingAsync(DESKTOP_SETTINGS_KEY, json);
         }
 
         /// <summary>

--- a/wasm2/HackerOs/HackerOs/OS/UI/Services/LauncherService.cs
+++ b/wasm2/HackerOs/HackerOs/OS/UI/Services/LauncherService.cs
@@ -214,7 +214,7 @@ namespace HackerOs.OS.UI.Services
                 
                 // Save the updated list
                 var updatedJson = JsonSerializer.Serialize(recentAppDictionary);
-                await _settingsService.SetSettingAsync("launcher", RECENT_APPS_KEY, updatedJson);
+                await _settingsService.SetSettingAsync(RECENT_APPS_KEY, updatedJson);
             }
             catch (Exception ex)
             {
@@ -244,7 +244,7 @@ namespace HackerOs.OS.UI.Services
                 
                 // Save the updated list
                 var updatedJson = JsonSerializer.Serialize(pinnedAppIds);
-                await _settingsService.SetSettingAsync("launcher", PINNED_APPS_KEY, updatedJson);
+                await _settingsService.SetSettingAsync(PINNED_APPS_KEY, updatedJson);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- normalize paths using `Path.GetFullPath`
- update DesktopSettingsService to use generics and correct methods
- allow derived components to set error messages
- provide content renderer helper in `ApplicationManager`
- fix HTTP server socket calls
- resolve routing and path ambiguities
- correct cryptography namespace usage

## Testing
- `dotnet build wasm2/HackerOs/HackerOs/HackerOs.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68472f2d6dd883238c1b10966d6d1ba9