### PR TITLE
Fix namespaces and event args

### DIFF
--- a/wasm2/HackerOs/HackerOs/OS/Applications/ApplicationManager.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Applications/ApplicationManager.cs
@@ -7,6 +7,7 @@ using HackerOs.OS.Kernel.Process;
 using HackerOs.OS.Kernel.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Components;
 using System.Collections.Concurrent;
 using System.Reflection;
 

--- a/wasm2/HackerOs/HackerOs/OS/Applications/Extensions/FileOpenExtensions.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Applications/Extensions/FileOpenExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using HackerOs.OS.IO.FileSystem;
 using HackerOs.OS.User;
@@ -39,7 +40,7 @@ public static class FileOpenExtensions
             // Normalize path and check if file exists
             // Normalize path using the public utility available for the virtual file system
             var normalizedPath = HackerOs.OS.System.IO.Path.NormalizePath(filePath);
-            if (!await fileSystem.FileExistsAsync(normalizedPath))
+            if (!await fileSystem.FileExistsAsync(normalizedPath, userSession.User))
             {
                 return false;
             }
@@ -66,7 +67,7 @@ public static class FileOpenExtensions
             var context = new ApplicationLaunchContext
             {
                 UserSession = userSession,
-                Arguments = new[] { normalizedPath },
+                Arguments = new List<string> { normalizedPath },
                 WorkingDirectory = System.IO.Path.GetDirectoryName(normalizedPath)
             };
             
@@ -109,7 +110,7 @@ public static class FileOpenExtensions
             // Normalize path and check if file exists
             // Normalize path using the public utility so callers don't rely on private helpers
             var normalizedPath = HackerOs.OS.System.IO.Path.NormalizePath(filePath);
-            if (!await fileSystem.FileExistsAsync(normalizedPath))
+            if (!await fileSystem.FileExistsAsync(normalizedPath, userSession.User))
             {
                 return false;
             }
@@ -118,7 +119,7 @@ public static class FileOpenExtensions
             var context = new ApplicationLaunchContext
             {
                 UserSession = userSession,
-                Arguments = new[] { normalizedPath },
+                Arguments = new List<string> { normalizedPath },
                 WorkingDirectory = System.IO.Path.GetDirectoryName(normalizedPath)
             };
             

--- a/wasm2/HackerOs/HackerOs/OS/Network/DNS/DnsResolver.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Network/DNS/DnsResolver.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using HackerOs.OS.IO.FileSystem;
 using System.Text.RegularExpressions;
 using HackerOs.OS.System.IO;
+using HackerOs.OS.User;
 
 namespace HackerOs.OS.Network.DNS
 {

--- a/wasm2/HackerOs/HackerOs/OS/System/Net/Http/HttpClient.cs
+++ b/wasm2/HackerOs/HackerOs/OS/System/Net/Http/HttpClient.cs
@@ -302,6 +302,10 @@ namespace HackerOs.OS.System.Net.Http
     /// </summary>
     public class HttpContentHeaders : Dictionary<string, IEnumerable<string>>
     {
+        /// <summary>
+        /// Gets or sets the Content-Type header value.
+        /// </summary>
+        public string? ContentType { get; set; }
     }
 
     /// <summary>

--- a/wasm2/HackerOs/HackerOs/OS/System/Net/Http/Json/JsonExtensions.cs
+++ b/wasm2/HackerOs/HackerOs/OS/System/Net/Http/Json/JsonExtensions.cs
@@ -16,7 +16,7 @@ namespace HackerOs.OS.System.Net.Http.Json
         /// </summary>
         public static async Task<T?> GetFromJsonAsync<T>(this HttpClient client, string requestUri, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
         {
-            var response = await client.GetAsync(requestUri, cancellationToken);
+            var response = await client.GetAsync(requestUri, cancellationToken.GetSystemToken());
             response.EnsureSuccessStatusCode();
             
             var content = await response.Content.ReadAsStringAsync();
@@ -41,7 +41,7 @@ namespace HackerOs.OS.System.Net.Http.Json
         {
             var json = JsonSerializer.Serialize(value, options);
             var content = new StringContent(json, "utf-8", "application/json");
-            return await client.PostAsync(requestUri, content, cancellationToken);
+            return await client.PostAsync(requestUri, content, cancellationToken.GetSystemToken());
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace HackerOs.OS.System.Net.Http.Json
         {
             var json = JsonSerializer.Serialize(value, options);
             var content = new StringContent(json, "utf-8", "application/json");
-            return await client.PutAsync(requestUri, content, cancellationToken);
+            return await client.PutAsync(requestUri, content, cancellationToken.GetSystemToken());
         }
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace HackerOs.OS.System.Net.Http.Json
             {
                 Content = content
             };
-            return await client.SendAsync(request, cancellationToken);
+            return await client.SendAsync(request, cancellationToken.GetSystemToken());
         }
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace HackerOs.OS.System.Net.Http.Json
         public JsonContent(object value, JsonSerializerOptions? options = null)
         {
             _jsonContent = JsonSerializer.Serialize(value, options);
-            Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+            Headers.ContentType = "application/json";
         }
 
         /// <summary>
@@ -115,11 +115,11 @@ namespace HackerOs.OS.System.Net.Http.Json
         public JsonContent(string json)
         {
             _jsonContent = json;
-            Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+            Headers.ContentType = "application/json";
         }        /// <summary>
         /// Serialize the HTTP content to a stream as an asynchronous operation
         /// </summary>
-        public async Task SerializeToStreamAsync(System.IO.Stream stream, TransportContext? context = null)
+        public async Task SerializeToStreamAsync(global::System.IO.Stream stream, TransportContext? context = null)
         {
             var bytes = global::System.Text.Encoding.UTF8.GetBytes(_jsonContent);
             await stream.WriteAsync(bytes, 0, bytes.Length);
@@ -154,7 +154,7 @@ namespace HackerOs.OS.System.Net.Http.Json
         public override async Task<System.IO.Stream> ReadAsStreamAsync()
         {
             var bytes = global::System.Text.Encoding.UTF8.GetBytes(_jsonContent);
-            return new System.IO.MemoryStream(bytes);
+            return new global::System.IO.MemoryStream(bytes);
         }
     }
 }

--- a/wasm2/HackerOs/HackerOs/OS/UI/Components/ApplicationLauncher.razor.cs
+++ b/wasm2/HackerOs/HackerOs/OS/UI/Components/ApplicationLauncher.razor.cs
@@ -335,7 +335,7 @@ namespace HackerOs.OS.UI.Components
         /// <summary>
         /// Handle application installed event
         /// </summary>
-        private async void OnApplicationInstalled(object? sender, ApplicationEventArgs e)
+        private async void OnApplicationInstalled(object? sender, ApplicationInstalledEventArgs e)
         {
             await LoadDataAsync();
         }
@@ -343,7 +343,7 @@ namespace HackerOs.OS.UI.Components
         /// <summary>
         /// Handle application uninstalled event
         /// </summary>
-        private async void OnApplicationUninstalled(object? sender, ApplicationEventArgs e)
+        private async void OnApplicationUninstalled(object? sender, ApplicationUninstalledEventArgs e)
         {
             await LoadDataAsync();
         }
@@ -351,7 +351,7 @@ namespace HackerOs.OS.UI.Components
         /// <summary>
         /// Handle application started event
         /// </summary>
-        private async void OnApplicationStarted(object? sender, ApplicationEventArgs e)
+        private async void OnApplicationStarted(object? sender, ApplicationLaunchedEventArgs e)
         {
             // Refresh recent apps when an application is started
             var recent = await LauncherService.GetRecentApplicationsAsync();
@@ -360,7 +360,7 @@ namespace HackerOs.OS.UI.Components
             await InvokeAsync(StateHasChanged);
         }
 
-        private async void OnApplicationClosed(object? sender, ApplicationEventArgs e)
+        private async void OnApplicationClosed(object? sender, ApplicationTerminatedEventArgs e)
         {
             RefreshRunningApplications();
             await InvokeAsync(StateHasChanged);


### PR DESCRIPTION
## Summary
- import missing Microsoft.AspNetCore.Components namespace
- fix FileOpenExtensions user check and list types
- add missing using statements
- update ApplicationLauncher event handlers
- add content-type field for HttpContentHeaders
- adjust JsonExtensions token conversion

## Testing
- `dotnet build wasm2/HackerOs/HackerOs/HackerOs.csproj -c Release` *(fails: 66 errors remain)*

------
https://chatgpt.com/codex/tasks/task_b_684734a9fa088323b342eb0d1f928641