### PR TITLE
Fix compile errors in HackerOS

### DIFF
--- a/wasm2/HackerOs/HackerOs/OS/Applications/Extensions/FileOpenExtensions.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Applications/Extensions/FileOpenExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using HackerOs.OS.IO.FileSystem;
@@ -46,7 +45,7 @@ public static class FileOpenExtensions
             }
             
             // Get file extension
-            var extension = System.IO.Path.GetExtension(normalizedPath);
+            var extension = global::System.IO.Path.GetExtension(normalizedPath);
             if (string.IsNullOrEmpty(extension))
             {
                 return false;
@@ -68,7 +67,7 @@ public static class FileOpenExtensions
             {
                 UserSession = userSession,
                 Arguments = new List<string> { normalizedPath },
-                WorkingDirectory = System.IO.Path.GetDirectoryName(normalizedPath)
+                WorkingDirectory = global::System.IO.Path.GetDirectoryName(normalizedPath)
             };
             
             var app = await applicationManager.LaunchApplicationAsync(appId, context);
@@ -120,7 +119,7 @@ public static class FileOpenExtensions
             {
                 UserSession = userSession,
                 Arguments = new List<string> { normalizedPath },
-                WorkingDirectory = System.IO.Path.GetDirectoryName(normalizedPath)
+                WorkingDirectory = global::System.IO.Path.GetDirectoryName(normalizedPath)
             };
             
             var app = await applicationManager.LaunchApplicationAsync(applicationId, context);
@@ -153,7 +152,7 @@ public static class FileOpenExtensions
         try
         {
             // Get file extension
-            var extension = System.IO.Path.GetExtension(filePath);
+            var extension = global::System.IO.Path.GetExtension(filePath);
             if (string.IsNullOrEmpty(extension))
             {
                 return false;

--- a/wasm2/HackerOs/HackerOs/OS/Applications/FileTypeRegistry.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Applications/FileTypeRegistry.cs
@@ -1,7 +1,6 @@
 using HackerOs.OS.Applications.Attributes;
 using HackerOs.OS.IO.FileSystem;
 using HackerOs.OS.User;
-using HackerOs.OS.IO.Utilities;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
@@ -300,7 +299,7 @@ public class FileTypeRegistry : IFileTypeRegistry
                 return null;
                 
             // Normalize path and verify file exists
-            var normalizedPath = Path.GetFullPath(filePath);
+            var normalizedPath = HackerOs.OS.System.IO.Path.GetFullPath(filePath);
             if (!await _fileSystem.FileExistsAsync(normalizedPath, UserManager.SystemUser))
                 return null;
                 

--- a/wasm2/HackerOs/HackerOs/OS/Shell/ShellContext.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Shell/ShellContext.cs
@@ -54,10 +54,11 @@ namespace HackerOs.OS.Shell
                 Environment["HOME"] = GetHomeDirectory();
             }
             Environment["PWD"] = WorkingDirectory;
-            Environment["PATH"] = "/bin:/usr/bin:/usr/local/bin";            Environment["SHELL"] = "/bin/bash";
+            Environment["PATH"] = "/bin:/usr/bin:/usr/local/bin";
+            Environment["SHELL"] = "/bin/bash";
         }        public async Task WriteLineAsync(string text)
         {
-            var bytes = Encoding.UTF8.GetBytes(text + Environment.NewLine);
+            var bytes = Encoding.UTF8.GetBytes(text + global::System.Environment.NewLine);
             await StandardOutput.WriteAsync(bytes);
             await StandardOutput.FlushAsync();
         }
@@ -69,7 +70,7 @@ namespace HackerOs.OS.Shell
             await StandardOutput.FlushAsync();
         }        public async Task WriteErrorAsync(string text)
         {
-            var bytes = Encoding.UTF8.GetBytes(text + Environment.NewLine);
+            var bytes = Encoding.UTF8.GetBytes(text + global::System.Environment.NewLine);
             await StandardError.WriteAsync(bytes);
             await StandardError.FlushAsync();
         }

--- a/wasm2/HackerOs/HackerOs/OS/System/Net/Http/Json/JsonExtensions.cs
+++ b/wasm2/HackerOs/HackerOs/OS/System/Net/Http/Json/JsonExtensions.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Net;
 using System.Net.Security;
+using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
+using HackerOs.OS.System.Net.Http;
 
 namespace HackerOs.OS.System.Net.Http.Json
 {

--- a/wasm2/HackerOs/HackerOs/OS/System/Text/Json/JsonSerializer.cs
+++ b/wasm2/HackerOs/HackerOs/OS/System/Text/Json/JsonSerializer.cs
@@ -41,7 +41,7 @@ namespace HackerOs.OS.System.Text.Json
             {
                 PropertyNamingPolicy = options.PropertyNamingPolicy == JsonNamingPolicy.CamelCase
                     ? System.Text.Json.JsonNamingPolicy.CamelCase
-                    : null,
+                    : (System.Text.Json.JsonNamingPolicy?)null,
                 WriteIndented = options.WriteIndented,
                 IgnoreNullValues = options.IgnoreNullValues,
                 PropertyNameCaseInsensitive = options.PropertyNameCaseInsensitive
@@ -74,7 +74,7 @@ namespace HackerOs.OS.System.Text.Json
             {
                 PropertyNamingPolicy = options.PropertyNamingPolicy == JsonNamingPolicy.CamelCase
                     ? System.Text.Json.JsonNamingPolicy.CamelCase
-                    : null,
+                    : (System.Text.Json.JsonNamingPolicy?)null,
                 WriteIndented = options.WriteIndented,
                 IgnoreNullValues = options.IgnoreNullValues,
                 PropertyNameCaseInsensitive = options.PropertyNameCaseInsensitive


### PR DESCRIPTION
## Summary
- disambiguate Path usage in file open helpers
- fix default environment initialization and newline handling in shell context
- repair Json extension methods and JSON serializer options
- clarify path handling when looking up recommended apps

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet build wasm2/HackerOs/HackerOs.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68474727fbf08323a5b57e6124ac8bdd