### PR TITLE
Fix compile issues in settings and file open

### DIFF
--- a/wasm2/HackerOs/HackerOs/OS/Applications/Extensions/FileOpenExtensions.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Applications/Extensions/FileOpenExtensions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using HackerOs.OS.IO.FileSystem;
 using HackerOs.OS.User;
-using HackerOs.OS.IO.Utilities;
 
 namespace HackerOs.OS.Applications.Extensions;
 
@@ -37,8 +36,9 @@ public static class FileOpenExtensions
         try
         {
             // Normalize path and check if file exists
-            // Normalize path using the public utility available for the virtual file system
-            var normalizedPath = HackerOs.OS.System.IO.Path.NormalizePath(filePath);
+            // Resolve to an absolute path using the public utility so callers do
+            // not rely on the internal NormalizePath helper
+            var normalizedPath = HackerOs.OS.System.IO.Path.GetFullPath(filePath);
             if (!await fileSystem.FileExistsAsync(normalizedPath, userSession.User))
             {
                 return false;
@@ -108,7 +108,7 @@ public static class FileOpenExtensions
         {
             // Normalize path and check if file exists
             // Normalize path using the public utility so callers don't rely on private helpers
-            var normalizedPath = HackerOs.OS.System.IO.Path.NormalizePath(filePath);
+            var normalizedPath = HackerOs.OS.System.IO.Path.GetFullPath(filePath);
             if (!await fileSystem.FileExistsAsync(normalizedPath, userSession.User))
             {
                 return false;

--- a/wasm2/HackerOs/HackerOs/OS/UI/Services/NotificationService.cs
+++ b/wasm2/HackerOs/HackerOs/OS/UI/Services/NotificationService.cs
@@ -1,4 +1,4 @@
-using HackerOs.OS.Core.Settings;
+using HackerOs.OS.Settings;
 using HackerOs.OS.UI.Models;
 using Microsoft.Extensions.Logging;
 using System;
@@ -229,7 +229,7 @@ namespace HackerOs.OS.UI.Services
             try
             {
                 var notificationsJson = JsonSerializer.Serialize(_notifications);
-                await _settingsService.SetSettingAsync(NOTIFICATIONS_KEY, notificationsJson);
+                await _settingsService.SetSettingAsync("notifications", NOTIFICATIONS_KEY, notificationsJson);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- use GetFullPath for resolving file paths
- adjust NotificationService to use new settings service API

## Testing
- `dotnet build wasm2/HackerOs/HackerOs.sln -c Debug` *(fails: 28 errors)*

------
https://chatgpt.com/codex/tasks/task_b_684cd4290dc4832393dfd57ae10bb7a1