### PR TITLE
Fix interface method and router constant

### DIFF
--- a/wasm2/HackerOs/HackerOs/OS/Applications/IApplicationManager.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Applications/IApplicationManager.cs
@@ -1,4 +1,5 @@
 using HackerOs.OS.User;
+using Microsoft.AspNetCore.Components;
 
 namespace HackerOs.OS.Applications;
 
@@ -136,4 +137,11 @@ public interface IApplicationManager
     /// </summary>
     /// <returns>A list of all application manifests</returns>
     IReadOnlyList<ApplicationManifest> GetAllApplications();
+
+    /// <summary>
+    /// Creates a render fragment to display the UI of a running application.
+    /// </summary>
+    /// <param name="application">Application instance.</param>
+    /// <returns>Render fragment for the application's UI.</returns>
+    RenderFragment GetApplicationContentRenderer(IApplication application);
 }

--- a/wasm2/HackerOs/HackerOs/OS/Network/WebServer/Framework/Router.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Network/WebServer/Framework/Router.cs
@@ -55,7 +55,7 @@ namespace HackerOs.OS.Network.WebServer.Framework
                         controllerType, 
                         method, 
                         defaultTemplate, 
-                        HttpMethod.GET.ToString(),
+                        HackerOs.OS.Network.HTTP.HttpMethod.GET.ToString(),
                         $"{controllerType.Name}.{method.Name}");
                     
                     _routes.Add(defaultRouteInfo);
@@ -69,7 +69,7 @@ namespace HackerOs.OS.Network.WebServer.Framework
                             controllerType,
                             method,
                             attr.Template,
-                            attr.HttpMethod ?? HttpMethod.GET.ToString(),
+                            attr.HttpMethod ?? HackerOs.OS.Network.HTTP.HttpMethod.GET.ToString(),
                             attr.Name ?? $"{controllerType.Name}.{method.Name}");
                         
                         _routes.Add(routeInfo);


### PR DESCRIPTION
## Summary
- add `GetApplicationContentRenderer` to `IApplicationManager`
- reference custom `HttpMethod` explicitly in router

## Testing
- `dotnet build wasm2/HackerOs/HackerOs.sln -clp:ErrorsOnly` *(fails: UserSettings method missing, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_684ceb635b60832392d1aaa1c8754b69