### PR TITLE
Fix token conversion and namespace issues

### DIFF
--- a/wasm2/HackerOs/HackerOs/OS/Applications/BuiltIn/TerminalEmulator.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Applications/BuiltIn/TerminalEmulator.cs
@@ -354,7 +354,7 @@ namespace HackerOs.OS.Applications.BuiltIn
 
         private async Task WriteLineAsync(string text)
         {
-            await WriteAsync(text + Environment.NewLine);
+            await WriteAsync(text + global::System.Environment.NewLine);
         }
 
         private async Task WriteAsync(string text)

--- a/wasm2/HackerOs/HackerOs/OS/IO/Utilities/File.cs
+++ b/wasm2/HackerOs/HackerOs/OS/IO/Utilities/File.cs
@@ -219,7 +219,7 @@ namespace HackerOs.OS.IO.Utilities
         /// <returns>A task representing the asynchronous operation</returns>
         public static async Task WriteAllLinesAsync(string path, IEnumerable<string> contents, Encoding encoding, IVirtualFileSystem fileSystem)
         {
-            var text = string.Join(Environment.NewLine, contents);
+            var text = string.Join(global::System.Environment.NewLine, contents);
             await WriteAllTextAsync(path, text, encoding, fileSystem);
         }
 
@@ -297,7 +297,7 @@ namespace HackerOs.OS.IO.Utilities
             if (linesToAppend.Length == 0)
                 return;
 
-            var textToAppend = Environment.NewLine + string.Join(Environment.NewLine, linesToAppend);
+            var textToAppend = global::System.Environment.NewLine + string.Join(global::System.Environment.NewLine, linesToAppend);
             await AppendAllTextAsync(path, textToAppend, encoding, fileSystem);
         }
 

--- a/wasm2/HackerOs/HackerOs/OS/Shell/CommandBase.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Shell/CommandBase.cs
@@ -1,4 +1,6 @@
 
+using System;
+using System.IO;
 using System.Text;
 using HackerOs.OS.IO.FileSystem;
 
@@ -42,7 +44,7 @@ public abstract class CommandBase : ICommand
     /// </summary>
     protected static async Task WriteLineAsync(Stream stream, string text, CancellationToken cancellationToken = default)
     {
-        var bytes = Encoding.UTF8.GetBytes(text + Environment.NewLine);
+        var bytes = Encoding.UTF8.GetBytes(text + global::System.Environment.NewLine);
         await stream.WriteAsync(bytes, cancellationToken);
     }
 

--- a/wasm2/HackerOs/HackerOs/OS/Shell/Commands/FindCommand.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Shell/Commands/FindCommand.cs
@@ -137,8 +137,9 @@ namespace HackerOs.OS.Shell.Commands
                 {
                     errors.Add($"find: {path}: {ex.Message}");
                 }
-            }            var output = string.Join(Environment.NewLine, results);
-            var errorOutput = string.Join(Environment.NewLine, errors);
+            }
+            var output = string.Join(global::System.Environment.NewLine, results);
+            var errorOutput = string.Join(global::System.Environment.NewLine, errors);
 
             if (!string.IsNullOrEmpty(output))
             {

--- a/wasm2/HackerOs/HackerOs/OS/Shell/Commands/GrepCommand.cs
+++ b/wasm2/HackerOs/HackerOs/OS/Shell/Commands/GrepCommand.cs
@@ -117,14 +117,14 @@ namespace HackerOs.OS.Shell.Commands
                 // Write results to stdout
                 if (results.Any())
                 {
-                    var output = string.Join(Environment.NewLine, results);
+                    var output = string.Join(global::System.Environment.NewLine, results);
                     await WriteLineAsync(stdout, output, cancellationToken);
                 }
 
                 // Write errors to stderr
                 if (errors.Any())
                 {
-                    var errorOutput = string.Join(Environment.NewLine, errors);
+                    var errorOutput = string.Join(global::System.Environment.NewLine, errors);
                     await WriteLineAsync(stderr, errorOutput, cancellationToken);
                 }
 

--- a/wasm2/HackerOs/HackerOs/OS/System/Net/Http/HttpClient.cs
+++ b/wasm2/HackerOs/HackerOs/OS/System/Net/Http/HttpClient.cs
@@ -247,7 +247,7 @@ namespace HackerOs.OS.System.Net.Http
 
         public abstract Task<string> ReadAsStringAsync();
         public abstract Task<byte[]> ReadAsByteArrayAsync();
-        public abstract Task<System.IO.Stream> ReadAsStreamAsync();
+        public abstract Task<global::System.IO.Stream> ReadAsStreamAsync();
 
         public virtual void Dispose() { }
     }
@@ -276,10 +276,10 @@ namespace HackerOs.OS.System.Net.Http
         public override Task<byte[]> ReadAsByteArrayAsync()
         {
             return Task.FromResult(System.Text.Encoding.UTF8.GetBytes(_content));
-        }        public override Task<System.IO.Stream> ReadAsStreamAsync()
+        }        public override Task<global::System.IO.Stream> ReadAsStreamAsync()
         {
             var bytes = System.Text.Encoding.UTF8.GetBytes(_content);
-            return Task.FromResult<System.IO.Stream>(new System.IO.MemoryStream(bytes));
+            return Task.FromResult<global::System.IO.Stream>(new global::System.IO.MemoryStream(bytes));
         }
     }
 

--- a/wasm2/HackerOs/HackerOs/OS/System/Net/Http/Json/JsonExtensions.cs
+++ b/wasm2/HackerOs/HackerOs/OS/System/Net/Http/Json/JsonExtensions.cs
@@ -15,7 +15,7 @@ namespace HackerOs.OS.System.Net.Http.Json
         /// <summary>
         /// Sends a GET request to the specified Uri and returns the value as a JSON string
         /// </summary>
-        public static async Task<T?> GetFromJsonAsync<T>(this HttpClient client, string requestUri, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
+        public static async Task<T?> GetFromJsonAsync<T>(this HackerOs.OS.System.Net.Http.HttpClient client, string requestUri, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
         {
             var response = await client.GetAsync(requestUri, cancellationToken.GetSystemToken());
             response.EnsureSuccessStatusCode();
@@ -30,7 +30,7 @@ namespace HackerOs.OS.System.Net.Http.Json
         /// <summary>
         /// Sends a GET request to the specified Uri and returns the value as a JSON string
         /// </summary>
-        public static async Task<T?> GetFromJsonAsync<T>(this HttpClient client, Uri requestUri, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
+        public static async Task<T?> GetFromJsonAsync<T>(this HackerOs.OS.System.Net.Http.HttpClient client, Uri requestUri, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
         {
             return await GetFromJsonAsync<T>(client, requestUri.ToString(), cancellationToken, options);
         }
@@ -38,7 +38,7 @@ namespace HackerOs.OS.System.Net.Http.Json
         /// <summary>
         /// Sends a POST request to the specified Uri containing the value serialized as JSON
         /// </summary>
-        public static async Task<HttpResponseMessage> PostAsJsonAsync<T>(this HttpClient client, string requestUri, T value, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
+        public static async Task<HttpResponseMessage> PostAsJsonAsync<T>(this HackerOs.OS.System.Net.Http.HttpClient client, string requestUri, T value, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
         {
             var json = JsonSerializer.Serialize(value, options);
             var content = new StringContent(json, "utf-8", "application/json");
@@ -48,7 +48,7 @@ namespace HackerOs.OS.System.Net.Http.Json
         /// <summary>
         /// Sends a POST request to the specified Uri containing the value serialized as JSON
         /// </summary>
-        public static async Task<HttpResponseMessage> PostAsJsonAsync<T>(this HttpClient client, Uri requestUri, T value, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
+        public static async Task<HttpResponseMessage> PostAsJsonAsync<T>(this HackerOs.OS.System.Net.Http.HttpClient client, Uri requestUri, T value, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
         {
             return await PostAsJsonAsync(client, requestUri.ToString(), value, cancellationToken, options);
         }
@@ -56,7 +56,7 @@ namespace HackerOs.OS.System.Net.Http.Json
         /// <summary>
         /// Sends a PUT request to the specified Uri containing the value serialized as JSON
         /// </summary>
-        public static async Task<HttpResponseMessage> PutAsJsonAsync<T>(this HttpClient client, string requestUri, T value, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
+        public static async Task<HttpResponseMessage> PutAsJsonAsync<T>(this HackerOs.OS.System.Net.Http.HttpClient client, string requestUri, T value, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
         {
             var json = JsonSerializer.Serialize(value, options);
             var content = new StringContent(json, "utf-8", "application/json");
@@ -66,7 +66,7 @@ namespace HackerOs.OS.System.Net.Http.Json
         /// <summary>
         /// Sends a PUT request to the specified Uri containing the value serialized as JSON
         /// </summary>
-        public static async Task<HttpResponseMessage> PutAsJsonAsync<T>(this HttpClient client, Uri requestUri, T value, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
+        public static async Task<HttpResponseMessage> PutAsJsonAsync<T>(this HackerOs.OS.System.Net.Http.HttpClient client, Uri requestUri, T value, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
         {
             return await PutAsJsonAsync(client, requestUri.ToString(), value, cancellationToken, options);
         }
@@ -74,7 +74,7 @@ namespace HackerOs.OS.System.Net.Http.Json
         /// <summary>
         /// Sends a PATCH request to the specified Uri containing the value serialized as JSON
         /// </summary>
-        public static async Task<HttpResponseMessage> PatchAsJsonAsync<T>(this HttpClient client, string requestUri, T value, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
+        public static async Task<HttpResponseMessage> PatchAsJsonAsync<T>(this HackerOs.OS.System.Net.Http.HttpClient client, string requestUri, T value, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
         {
             var json = JsonSerializer.Serialize(value, options);
             var content = new StringContent(json, "utf-8", "application/json");
@@ -88,7 +88,7 @@ namespace HackerOs.OS.System.Net.Http.Json
         /// <summary>
         /// Sends a PATCH request to the specified Uri containing the value serialized as JSON
         /// </summary>
-        public static async Task<HttpResponseMessage> PatchAsJsonAsync<T>(this HttpClient client, Uri requestUri, T value, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
+        public static async Task<HttpResponseMessage> PatchAsJsonAsync<T>(this HackerOs.OS.System.Net.Http.HttpClient client, Uri requestUri, T value, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
         {
             return await PatchAsJsonAsync(client, requestUri.ToString(), value, cancellationToken, options);
         }
@@ -152,7 +152,7 @@ namespace HackerOs.OS.System.Net.Http.Json
         /// <summary>
         /// Serialize the HTTP content to a stream as an asynchronous operation
         /// </summary>
-        public override Task<System.IO.Stream> ReadAsStreamAsync()
+        public override Task<global::System.IO.Stream> ReadAsStreamAsync()
         {
             var bytes = global::System.Text.Encoding.UTF8.GetBytes(_jsonContent);
             global::System.IO.Stream stream = new global::System.IO.MemoryStream(bytes);


### PR DESCRIPTION
## Summary
- correct newline helpers to use `System.Environment`
- fix filesystem line joining with global newline
- update HttpClient extensions to use correct HttpClient type
- normalize HttpContent stream types

## Testing
- `dotnet build wasm2/HackerOs/HackerOs.sln` *(fails: CS0029 in JsonSerializer.cs)*

------
https://chatgpt.com/codex/tasks/task_b_684cfa908a148323a92a0e239d01e02a