### PR TITLE
Fix HackerOs compilation by correcting namespace uses

### DIFF
--- a/wasm2/HackerOs/HackerOs/OS/System/Net/Http/HttpClient.cs
+++ b/wasm2/HackerOs/HackerOs/OS/System/Net/Http/HttpClient.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Threading;
+using global::System.Threading;
 using System.Threading.Tasks;
 
 
@@ -31,7 +31,7 @@ namespace HackerOs.OS.System.Net.Http
         /// <summary>
         /// Sends an HTTP GET request
         /// </summary>
-        public async Task<HttpResponseMessage> GetAsync(string requestUri, CancellationToken cancellationToken = default)
+        public async Task<HttpResponseMessage> GetAsync(string requestUri, global::System.Threading.CancellationToken cancellationToken = default)
         {
             var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
             return await SendAsync(request, cancellationToken);
@@ -40,7 +40,7 @@ namespace HackerOs.OS.System.Net.Http
         /// <summary>
         /// Sends an HTTP POST request
         /// </summary>
-        public async Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent? content, CancellationToken cancellationToken = default)
+        public async Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent? content, global::System.Threading.CancellationToken cancellationToken = default)
         {
             var request = new HttpRequestMessage(HttpMethod.Post, requestUri)
             {
@@ -52,7 +52,7 @@ namespace HackerOs.OS.System.Net.Http
         /// <summary>
         /// Sends an HTTP PUT request
         /// </summary>
-        public async Task<HttpResponseMessage> PutAsync(string requestUri, HttpContent? content, CancellationToken cancellationToken = default)
+        public async Task<HttpResponseMessage> PutAsync(string requestUri, HttpContent? content, global::System.Threading.CancellationToken cancellationToken = default)
         {
             var request = new HttpRequestMessage(HttpMethod.Put, requestUri)
             {
@@ -64,7 +64,7 @@ namespace HackerOs.OS.System.Net.Http
         /// <summary>
         /// Sends an HTTP DELETE request
         /// </summary>
-        public async Task<HttpResponseMessage> DeleteAsync(string requestUri, CancellationToken cancellationToken = default)
+        public async Task<HttpResponseMessage> DeleteAsync(string requestUri, global::System.Threading.CancellationToken cancellationToken = default)
         {
             var request = new HttpRequestMessage(HttpMethod.Delete, requestUri);
             return await SendAsync(request, cancellationToken);
@@ -73,7 +73,7 @@ namespace HackerOs.OS.System.Net.Http
         /// <summary>
         /// Sends an HTTP request
         /// </summary>
-        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken = default)
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, global::System.Threading.CancellationToken cancellationToken = default)
         {
             if (_disposed)
                 throw new ObjectDisposedException(nameof(HttpClient));

--- a/wasm2/HackerOs/HackerOs/OS/System/Net/Http/Json/JsonExtensions.cs
+++ b/wasm2/HackerOs/HackerOs/OS/System/Net/Http/Json/JsonExtensions.cs
@@ -17,7 +17,8 @@ namespace HackerOs.OS.System.Net.Http.Json
         /// </summary>
         public static async Task<T?> GetFromJsonAsync<T>(this HackerOs.OS.System.Net.Http.HttpClient client, string requestUri, HackerOs.OS.System.Threading.CancellationToken cancellationToken = default, JsonSerializerOptions? options = null)
         {
-            var response = await client.GetAsync(requestUri, cancellationToken.GetSystemToken());
+            global::System.Threading.CancellationToken systemToken = cancellationToken.GetSystemToken();
+            var response = await client.GetAsync(requestUri, systemToken);
             response.EnsureSuccessStatusCode();
             
             var content = await response.Content.ReadAsStringAsync();
@@ -42,7 +43,8 @@ namespace HackerOs.OS.System.Net.Http.Json
         {
             var json = JsonSerializer.Serialize(value, options);
             var content = new StringContent(json, "utf-8", "application/json");
-            return await client.PostAsync(requestUri, content, cancellationToken.GetSystemToken());
+            global::System.Threading.CancellationToken systemToken = cancellationToken.GetSystemToken();
+            return await client.PostAsync(requestUri, content, systemToken);
         }
 
         /// <summary>
@@ -60,7 +62,8 @@ namespace HackerOs.OS.System.Net.Http.Json
         {
             var json = JsonSerializer.Serialize(value, options);
             var content = new StringContent(json, "utf-8", "application/json");
-            return await client.PutAsync(requestUri, content, cancellationToken.GetSystemToken());
+            global::System.Threading.CancellationToken systemToken = cancellationToken.GetSystemToken();
+            return await client.PutAsync(requestUri, content, systemToken);
         }
 
         /// <summary>
@@ -82,7 +85,8 @@ namespace HackerOs.OS.System.Net.Http.Json
             {
                 Content = content
             };
-            return await client.SendAsync(request, cancellationToken.GetSystemToken());
+            global::System.Threading.CancellationToken systemToken = cancellationToken.GetSystemToken();
+            return await client.SendAsync(request, systemToken);
         }
 
         /// <summary>
@@ -154,7 +158,7 @@ namespace HackerOs.OS.System.Net.Http.Json
         /// </summary>
         public override Task<global::System.IO.Stream> ReadAsStreamAsync()
         {
-            var bytes = global::System.Text.Encoding.UTF8.GetBytes(_jsonContent);
+            var bytes = System.Text.Encoding.UTF8.GetBytes(_jsonContent);
             global::System.IO.Stream stream = new global::System.IO.MemoryStream(bytes);
             return Task.FromResult(stream);
         }

--- a/wasm2/HackerOs/HackerOs/OS/System/Text/Json/JsonSerializer.cs
+++ b/wasm2/HackerOs/HackerOs/OS/System/Text/Json/JsonSerializer.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Text.Json;
-using System.Text.Json.Serialization;
+// Use fully qualified names to avoid clashes with the local
+// JsonSerializerOptions and JsonNamingPolicy types declared below.
 using System.Threading.Tasks;
 
 namespace HackerOs.OS.System.Text.Json
@@ -12,9 +12,9 @@ namespace HackerOs.OS.System.Text.Json
     /// </summary>
     public static class JsonSerializer
     {
-        private static readonly System.Text.Json.JsonSerializerOptions _defaultOptions = new()
+        private static readonly global::System.Text.Json.JsonSerializerOptions _defaultOptions = new()
         {
-            PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase,
+            PropertyNamingPolicy = global::System.Text.Json.JsonNamingPolicy.CamelCase,
             WriteIndented = true,
             PropertyNameCaseInsensitive = true
         };
@@ -26,7 +26,7 @@ namespace HackerOs.OS.System.Text.Json
         /// <returns>A JSON string representation of the value.</returns>
         public static string Serialize(object value)
         {
-            return System.Text.Json.JsonSerializer.Serialize(value, _defaultOptions);
+            return global::System.Text.Json.JsonSerializer.Serialize(value, _defaultOptions);
         }
 
         /// <summary>
@@ -42,7 +42,7 @@ namespace HackerOs.OS.System.Text.Json
                     ? global::System.Text.Json.JsonNamingPolicy.CamelCase
                     : null;
 
-            var wrappedOptions = new System.Text.Json.JsonSerializerOptions
+            var wrappedOptions = new global::System.Text.Json.JsonSerializerOptions
             {
                 PropertyNamingPolicy = namingPolicy,
                 WriteIndented = options.WriteIndented,
@@ -50,7 +50,7 @@ namespace HackerOs.OS.System.Text.Json
                 PropertyNameCaseInsensitive = options.PropertyNameCaseInsensitive
             };
 
-            return System.Text.Json.JsonSerializer.Serialize(value, wrappedOptions);
+            return global::System.Text.Json.JsonSerializer.Serialize(value, wrappedOptions);
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace HackerOs.OS.System.Text.Json
         /// <returns>A deserialized instance of type T.</returns>
         public static T Deserialize<T>(string json)
         {
-            return System.Text.Json.JsonSerializer.Deserialize<T>(json, _defaultOptions);
+            return global::System.Text.Json.JsonSerializer.Deserialize<T>(json, _defaultOptions);
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace HackerOs.OS.System.Text.Json
                     ? global::System.Text.Json.JsonNamingPolicy.CamelCase
                     : null;
 
-            var wrappedOptions = new System.Text.Json.JsonSerializerOptions
+            var wrappedOptions = new global::System.Text.Json.JsonSerializerOptions
             {
                 PropertyNamingPolicy = namingPolicy,
                 WriteIndented = options.WriteIndented,
@@ -86,7 +86,7 @@ namespace HackerOs.OS.System.Text.Json
                 PropertyNameCaseInsensitive = options.PropertyNameCaseInsensitive
             };
 
-            return System.Text.Json.JsonSerializer.Deserialize<T>(json, wrappedOptions);
+            return global::System.Text.Json.JsonSerializer.Deserialize<T>(json, wrappedOptions);
         }
     }
 

--- a/wasm2/HackerOs/HackerOs/OS/System/Threading/Threading.cs
+++ b/wasm2/HackerOs/HackerOs/OS/System/Threading/Threading.cs
@@ -86,11 +86,11 @@ namespace HackerOs.OS.System.Threading
         /// <summary>
         /// Get the underlying System.Threading.CancellationToken
         /// </summary>
-        public System.Threading.CancellationToken GetSystemToken()
+        public global::System.Threading.CancellationToken GetSystemToken()
         {
-            return _isCancellationRequested ? 
-                new System.Threading.CancellationToken(true) : 
-                System.Threading.CancellationToken.None;
+            return _isCancellationRequested ?
+                new global::System.Threading.CancellationToken(true) :
+                global::System.Threading.CancellationToken.None;
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure System namespaces use `global::` prefixes to avoid conflicts
- correct CancellationToken wrapper to return .NET tokens
- update JSON extensions and HTTP client to use correct tokens
- maintain Virtual MemoryStream operations with global namespaces

## Testing
- `dotnet build wasm2/HackerOs/HackerOs/HackerOs.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_b_684cfd60bfb083239796566050d3d94e