### PR TITLE
Document common pitfalls from static-asset, manifest, and E2E harness fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@
 
 ---
 
+**Before you start:** read [`wasm2/HackerOs/docs/common-pitfalls.md`](wasm2/HackerOs/docs/common-pitfalls.md) — recurring mistakes already made (and fixed) once in this codebase around static-asset routing, `AppManifest`/schema drift, IndexedDB versioning, and E2E test harness setup. Each one was expensive to re-diagnose from scratch; don't repeat them.
+
+---
+
 ## I. CRITICAL DIRECTIVES:
 
 1.  **Strict Directory Structure for New Code:**

--- a/wasm2/HackerOs/docs/README.md
+++ b/wasm2/HackerOs/docs/README.md
@@ -20,6 +20,7 @@ Read these first regardless of what you're about to work on.
 | [`hosting-model.md`](hosting-model.md) | The three host projects (Ecosystem PWA, `test/test` debug harness, optional Server) and how they relate. |
 | [`implementation-status.md`](implementation-status.md) | The current, authoritative state of the migration — what's built, what's open, test counts. |
 | [`webassembly-debugging.md`](webassembly-debugging.md) | How to run and debug the WASM host locally. |
+| [`common-pitfalls.md`](common-pitfalls.md) | Recurring mistakes already made once in this codebase — static-asset routing, manifest/schema drift, IndexedDB versioning, E2E harness setup. Read before touching any of those. |
 
 ## Building an app on HackerOS
 

--- a/wasm2/HackerOs/docs/common-pitfalls.md
+++ b/wasm2/HackerOs/docs/common-pitfalls.md
@@ -1,0 +1,157 @@
+# Common Pitfalls
+
+Recurring mistakes this codebase has already made at least once, each expensive
+to re-diagnose from scratch. Read this before touching static web assets,
+`AppManifest`, the IndexedDB schema, or an E2E test harness. Every entry below
+was found and fixed for real in this project; treat a fresh occurrence as a
+regression, not a surprise.
+
+## 1. A referenced Blazor WASM "app" project's static assets are unprefixed, not `_content/{Project}/...`
+
+`OS/HackerOs.Ecosystem` is a `Microsoft.NET.Sdk.BlazorWebAssembly` **app**, not
+a Razor Class Library, but `test/test` and `Server/HackerOs.Server` both
+`ProjectReference` it to reuse its component tree (ADR 0027). When a project
+reference is consumed this way, ASP.NET Core's static web assets pipeline
+exposes Ecosystem's own `wwwroot`-relative paths **unprefixed** at the
+composed host (e.g. `wwwroot/css/app.css` → route `css/app.css`), unlike a
+true Razor Class Library, whose assets get the `_content/{Library}/...`
+prefix you'd expect. `@Assets["app.css"]` and `_content/HackerOs.Ecosystem/css/app.css`
+are both wrong keys for this file; the correct one is `css/app.css` (or
+`@Assets["css/app.css"]` if you want fingerprinting).
+
+**Why this bites hard:** the wrong key doesn't error — if the host also has
+its own file at that literal path (e.g. a leftover `dotnet new blazor`
+scaffold `wwwroot/app.css`), the lookup silently resolves to *that* instead,
+and the host renders with no error, no missing-file warning, just visibly
+wrong styling (or worse, only subtly wrong colors from CSS custom-property
+fallbacks). This is exactly what happened: `test/test` and
+`Server/HackerOs.Server` each carried their own unmodified scaffold
+`wwwroot/app.css`, so `@Assets["app.css"]` "worked" and matched the decoy file
+for the life of both hosts, and neither host ever rendered the real
+`--hos-*` design tokens. See `webassembly-debugging.md` for the full writeup
+and the fix.
+
+**Rule:** never give a host project (`test/test`, `Server/HackerOs.Server`) its
+own physical copy of an asset that's supposed to come from a referenced
+project — a decoy file is what makes the wrong lookup key look correct. If you
+add a fourth host, verify its static-asset route by checking the referenced
+project's own `*.staticwebassets.endpoints.json` in its build output, not by
+guessing the URL from convention.
+
+## 2. `AppManifestJsonSerializer`'s allowlist must be updated whenever `AppManifest` gains a property
+
+`AppManifestJsonSerializer.DeserializeStrict` hand-validates every top-level
+(and several nested) property name against a hardcoded allowlist before
+deserializing (`ValidateObject`, `AppManifestJsonSerializer.cs`). This is by
+design (ADR 0010) — it exists to reject typos and drift in manifest JSON — but
+it means the allowlist is a second place, separate from the `AppManifest`
+record itself, that must be kept in sync by hand.
+
+ADR 0040 added `AppManifest.DeclaredTopicPermissions` (JSON:
+`declaredTopicPermissions`) without updating this allowlist, so
+`DeserializeStrict` rejected the canonical manifest fixture — and would reject
+any real manifest using the field — with `Unknown property
+'declaredTopicPermissions' at 'manifest'`. `HackerOs.App.Abstractions.Tests`
+didn't catch it because none of its tests round-trip the canonical fixture
+through `DeserializeStrict`; only `HackerOs.Infrastructure.Browser.Tests`
+happened to exercise that path.
+
+**Rule:** any change that adds, renames, or nests a new `AppManifest` property
+must add the matching entry to `ValidateObject`'s allowlist (and, for a
+nested object/array, a `case` in the `switch` with its own allowed sub-keys)
+in the same change. After adding a manifest property, round-trip the
+canonical fixture (`Schema/Fixtures/app-manifest.canonical.json`) through
+`AppManifestJsonSerializer.DeserializeStrict` — by hand or via a test — before
+considering the change done.
+
+## 3. Never hardcode an IndexedDB schema version literal — always reference `HackerOsIndexedDbSchema.CurrentVersion`
+
+Every real repository in `Infrastructure/HackerOs.Infrastructure.Browser`
+correctly threads `HackerOsIndexedDbSchema.CurrentVersion` through
+`IndexedDbInteropAdapter.OpenAsync`/`ExecuteAsync`. But
+`Tests/HackerOs.BrowserHarness.Tests/App.razor`'s `VerifyOrphanCleanupAsync`
+bypasses the adapter and calls the JS module's `executeTransaction` directly,
+with the database version hardcoded as the literal `2` — stale from before
+the schema was bumped to `4` (ADR 0028/0029) and never updated. The JS
+module's `connections` cache is keyed by `` `${databaseName}:${version}` ``,
+so a call with the wrong version doesn't find the already-open connection at
+version 4 and throws `IndexedDB database 'hackeros' version 2 is not open.`
+
+**Why this was hard to isolate:** the failure is deterministic but every
+plausible-sounding cause is a dead end — the physical database really is at
+version 4 (confirmed via `indexedDB.databases()`), a full `bin`/`obj` wipe and
+clean rebuild changes nothing, and the browser's own stack trace mixes in
+stale URLs from unrelated ports (a red herring from Chrome's cross-navigation
+compiled-code cache, not the actual bug). The only way to find it was to
+`grep` for the JS interop method name `"executeTransaction"` as a C# string
+literal across the whole repo, not just the schema/adapter files — this
+surfaces every call site, including ones that don't go through the adapter.
+
+**Rule:** if you ever need to call `indexedDb.js` directly instead of through
+`IndexedDbInteropAdapter`, pass `HackerOsIndexedDbSchema.CurrentVersion`, never
+a literal. If a mysterious "database version N is not open" error shows a
+version that doesn't match `CurrentVersion`, `grep -rn '"executeTransaction"'`
+(or `"openDatabase"`) across the whole repo before assuming it's a build- or
+browser-cache problem.
+
+## 4. `dotnet run` for an E2E test harness needs `ASPNETCORE_ENVIRONMENT=Development` set explicitly
+
+Several E2E suites (`HackerOs.E2E.Tests`, `HackerOs.UI.E2E.Tests`) spawn a
+host project as a child `dotnet run` process via `Process.Start`. A child
+process inherits environment variables from whatever shell invoked `dotnet
+test` — in an IDE that's often `Development` by convention, but in a plain
+shell (and in CI) `ASPNETCORE_ENVIRONMENT` is usually unset, so the spawned
+host defaults to `Production`.
+
+In `Production`, `app.MapStaticAssets()` still wires up
+`StaticAssetDevelopmentRuntimeHandler` (despite the name), which expects every
+static web asset to resolve to a physical file under the host's own
+`wwwroot` for its dev-time patching checks. Assets composed from a referenced
+project or NuGet package (MudBlazor, `HackerOs.Ecosystem`,
+`HackerOs.Platform.Blazor`) aren't physical files under the host's `wwwroot`
+— every one of them 500s, and the harness never finishes booting. From the
+test's side this looks like `net::ERR_CONNECTION_REFUSED` or "the browser
+harness did not become ready" — nothing points at the environment variable.
+
+**Rule:** any `ProcessStartInfo` that spawns `dotnet run` (or `dotnet
+exec`/published binary) for one of the three host projects as a test harness
+must explicitly set `startInfo.Environment["ASPNETCORE_ENVIRONMENT"] =
+"Development"`. Don't rely on the invoking shell's environment. See
+`HackerOs.UI.E2E.Tests/E2ESupport.cs`'s `StartHarness` for the fix.
+
+## 5. E2E test harnesses launched with `--configuration Release` need a Release build first
+
+`HackerOs.E2E.Tests` and `HackerOs.UI.E2E.Tests` both spawn their harness with
+`--configuration Release`. `dotnet build HackerOs.sln -c Debug` alone leaves
+every Release output directory empty, so the spawned process crashes
+immediately with `The static resources manifest file '...staticwebassets.
+endpoints.json' was not found` — which, again, surfaces to the test as a
+`ERR_CONNECTION_REFUSED`/"harness did not become ready" timeout, not as a
+build error.
+
+**Rule:** before running any E2E suite locally, build both configurations:
+`dotnet build HackerOs.sln -c Debug` (for the test project itself) and
+`dotnet build HackerOs.sln -c Release` (for the spawned harness). CI presumably
+already does this as part of its normal build matrix; a fresh local clone or
+worktree will not have a Release output directory yet.
+
+## 6. Don't run the E2E/UI-E2E/PWA-E2E suites in parallel against each other
+
+`dotnet test HackerOs.sln` runs every test project's suite concurrently by
+default. The three Playwright-based suites (`HackerOs.E2E.Tests`,
+`HackerOs.UI.E2E.Tests`, `HackerOs.Pwa.E2E.Tests`) each spawn their own
+`dotnet run`/`dotnet publish` child processes and reserve their own ports —
+running all three at once under `dotnet test HackerOs.sln` produces spurious,
+non-reproducible failures (`dotnet publish` failing with exit code 1,
+connection-refused harness boots) purely from resource contention, not from
+anything wrong in the code under test. The same tests reliably pass when run
+one project at a time.
+
+**Rule:** when investigating an E2E failure, always reproduce it by running
+that one test project's suite in isolation
+(`dotnet test Tests/HackerOs.E2E.Tests -c Debug --no-build`, etc.) before
+concluding it's a real regression. If `dotnet test HackerOs.sln` reports E2E
+failures but the same tests pass individually, that's resource contention in
+the environment, not a bug in the app — filter E2E projects out of routine
+solution-wide test runs (`--filter "FullyQualifiedName!~E2E.Tests&
+FullyQualifiedName!~Pwa.E2E"`) and run them separately.


### PR DESCRIPTION
## Summary

- Adds `wasm2/HackerOs/docs/common-pitfalls.md`, capturing six mistakes found and fixed while merging `origin/main` into #81:
  1. Referenced Blazor WASM "app" project static assets resolve **unprefixed**, not under `_content/{Project}/...` — the root cause of the `app.css` single-source bug.
  2. `AppManifestJsonSerializer`'s strict-deserialization allowlist is a second source of truth that must be updated whenever `AppManifest` gains a property (missed for ADR 0040's `DeclaredTopicPermissions`).
  3. Never hardcode an IndexedDB schema version literal — always use `HackerOsIndexedDbSchema.CurrentVersion` (a stale `2` literal broke a harness contract test).
  4. E2E harnesses spawned via `Process.Start` need `ASPNETCORE_ENVIRONMENT=Development` set explicitly — it isn't inherited from a plain shell/CI.
  5. E2E suites that launch their harness with `--configuration Release` need a Release build first, or they fail with a misleading connection-refused/timeout instead of a build error.
  6. Don't run the Playwright E2E suites (`HackerOs.E2E.Tests`, `HackerOs.UI.E2E.Tests`, `HackerOs.Pwa.E2E.Tests`) in parallel via `dotnet test HackerOs.sln` — they contend for ports/publish targets and produce spurious failures; always reproduce a suspected E2E regression by running that one project in isolation first.
- Links the new doc from `wasm2/HackerOs/docs/README.md`'s index and from `AGENTS.md` as required reading before touching any of the above.

Docs-only change; no code touched.

## Test plan

- [x] N/A — documentation only, no build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)